### PR TITLE
feat: responsividade mobile em todas as telas

### DIFF
--- a/frontend/src/app/components/ForgotPassword.tsx
+++ b/frontend/src/app/components/ForgotPassword.tsx
@@ -16,11 +16,11 @@ export function ForgotPassword() {
     return (
       <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-50 via-yellow-50 to-red-50 p-4">
         <div className="w-full max-w-md">
-          <div className="bg-white rounded-2xl shadow-xl p-8 text-center">
-            <div className="inline-flex items-center justify-center w-20 h-20 bg-green-100 rounded-full mb-6">
-              <CheckCircle className="w-10 h-10 text-green-600" />
+          <div className="bg-white rounded-2xl shadow-xl p-5 sm:p-8 text-center">
+            <div className="inline-flex items-center justify-center w-16 h-16 sm:w-20 sm:h-20 bg-green-100 rounded-full mb-4 sm:mb-6">
+              <CheckCircle className="w-8 h-8 sm:w-10 sm:h-10 text-green-600" />
             </div>
-            <h1 className="text-3xl mb-3">Email Enviado!</h1>
+            <h1 className="text-2xl sm:text-3xl mb-3">Email Enviado!</h1>
             <p className="text-muted-foreground mb-8">
               Enviamos instruções para recuperação de senha para <strong>{email}</strong>.
               Verifique sua caixa de entrada e spam.
@@ -41,11 +41,11 @@ export function ForgotPassword() {
   return (
     <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-50 via-yellow-50 to-red-50 p-4">
       <div className="w-full max-w-md">
-        <div className="bg-white rounded-2xl shadow-xl p-8">
-          <div className="text-center mb-8">
-            <div className="flex justify-center mb-6"><Logo size="cover" /></div>
-            <h1 className="text-3xl mb-2">Esqueceu a Senha?</h1>
-            <p className="text-muted-foreground">
+        <div className="bg-white rounded-2xl shadow-xl p-5 sm:p-8">
+          <div className="text-center mb-6 sm:mb-8">
+            <div className="flex justify-center mb-4 sm:mb-6"><Logo size="cover" /></div>
+            <h1 className="text-2xl sm:text-3xl mb-2">Esqueceu a Senha?</h1>
+            <p className="text-sm sm:text-base text-muted-foreground">
               Sem problemas! Digite seu email e enviaremos instruções para recuperá-la.
             </p>
           </div>

--- a/frontend/src/app/components/LearningScreen.tsx
+++ b/frontend/src/app/components/LearningScreen.tsx
@@ -54,19 +54,19 @@ export function LearningScreen() {
   const [expanded, setExpanded] = useState<number | null>(1);
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-yellow-50 to-red-50 p-4">
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-yellow-50 to-red-50 p-3 sm:p-4">
       <div className="max-w-5xl mx-auto">
-        <div className="flex items-center justify-between mb-6">
-          <Link to="/aluno/dashboard" className="flex items-center gap-2 text-muted-foreground hover:text-foreground">
-            <ArrowLeft className="w-5 h-5" /> Voltar
+        <div className="flex items-center justify-between mb-4 sm:mb-6 gap-2">
+          <Link to="/aluno/dashboard" className="flex items-center gap-1 sm:gap-2 text-muted-foreground hover:text-foreground shrink-0">
+            <ArrowLeft className="w-5 h-5" /> <span className="hidden sm:inline">Voltar</span>
           </Link>
-          <h1 className="text-2xl">Área de Aprendizagem</h1>
-          <div className="w-20" />
+          <h1 className="text-lg sm:text-2xl text-center">Área de Aprendizagem</h1>
+          <div className="w-8 sm:w-20" />
         </div>
 
-        <div className="bg-gradient-to-r from-blue-600 to-blue-700 text-white rounded-2xl p-6 mb-6 shadow-xl">
-          <h2 className="text-2xl mb-2">Trilha de Aprendizagem</h2>
-          <p className="opacity-90 mb-4">Domine a morfologia em 5 módulos completos</p>
+        <div className="bg-gradient-to-r from-blue-600 to-blue-700 text-white rounded-xl sm:rounded-2xl p-4 sm:p-6 mb-4 sm:mb-6 shadow-xl">
+          <h2 className="text-xl sm:text-2xl mb-2">Trilha de Aprendizagem</h2>
+          <p className="text-sm sm:text-base opacity-90 mb-3 sm:mb-4">Domine a morfologia em 5 módulos completos</p>
           <div className="flex items-center gap-4">
             <div className="flex-1 bg-white/20 rounded-full h-3 overflow-hidden">
               <div className="bg-yellow-400 h-full" style={{ width: '40%' }} />
@@ -75,31 +75,31 @@ export function LearningScreen() {
           </div>
         </div>
 
-        <div className="space-y-4">
+        <div className="space-y-3 sm:space-y-4">
           {modules.map((mod) => (
-            <div key={mod.id} className="bg-white rounded-2xl shadow-lg overflow-hidden">
+            <div key={mod.id} className="bg-white rounded-xl sm:rounded-2xl shadow-lg overflow-hidden">
               <button
                 onClick={() => setExpanded(expanded === mod.id ? null : mod.id)}
-                className="w-full p-6 flex items-center gap-4 hover:bg-gray-50 transition-colors text-left"
+                className="w-full p-3 sm:p-6 flex items-center gap-3 sm:gap-4 hover:bg-gray-50 transition-colors text-left"
               >
-                <div className={`w-14 h-14 ${mod.color} rounded-xl flex items-center justify-center flex-shrink-0`}>
+                <div className={`w-10 h-10 sm:w-14 sm:h-14 ${mod.color} rounded-lg sm:rounded-xl flex items-center justify-center flex-shrink-0`}>
                   {mod.completed ? (
-                    <CheckCircle className="w-7 h-7 text-white" />
+                    <CheckCircle className="w-5 h-5 sm:w-7 sm:h-7 text-white" />
                   ) : (
-                    <BookOpen className="w-7 h-7 text-white" />
+                    <BookOpen className="w-5 h-5 sm:w-7 sm:h-7 text-white" />
                   )}
                 </div>
                 <div className="flex-1 min-w-0">
-                  <div className="flex items-center gap-2 mb-1">
-                    <span className="text-sm text-muted-foreground">Módulo {mod.id}</span>
+                  <div className="flex items-center gap-2 mb-0.5 sm:mb-1">
+                    <span className="text-xs sm:text-sm text-muted-foreground">Módulo {mod.id}</span>
                     {mod.completed && (
                       <span className="text-xs px-2 py-0.5 bg-green-100 text-green-700 rounded-full">
                         Concluído
                       </span>
                     )}
                   </div>
-                  <h3 className="text-xl mb-1">{mod.title}</h3>
-                  <p className="text-muted-foreground text-sm">{mod.description}</p>
+                  <h3 className="text-base sm:text-xl mb-0.5 sm:mb-1">{mod.title}</h3>
+                  <p className="text-muted-foreground text-xs sm:text-sm line-clamp-2">{mod.description}</p>
                 </div>
                 <div className="text-right hidden sm:block">
                   <div className="text-sm text-muted-foreground">{mod.duration}</div>
@@ -107,18 +107,18 @@ export function LearningScreen() {
               </button>
 
               {expanded === mod.id && (
-                <div className="border-t border-border p-6 bg-gray-50">
-                  <h4 className="mb-3">Aulas deste módulo:</h4>
-                  <div className="space-y-2 mb-4">
+                <div className="border-t border-border p-3 sm:p-6 bg-gray-50">
+                  <h4 className="text-sm sm:text-base mb-2 sm:mb-3">Aulas deste módulo:</h4>
+                  <div className="space-y-2 mb-3 sm:mb-4">
                     {mod.lessons.map((lesson, idx) => (
-                      <div key={idx} className="flex items-center gap-3 p-3 bg-white rounded-lg">
-                        <PlayCircle className="w-5 h-5 text-primary flex-shrink-0" />
-                        <span className="flex-1">{lesson}</span>
-                        <span className="text-sm text-muted-foreground">~5 min</span>
+                      <div key={idx} className="flex items-center gap-2 sm:gap-3 p-2 sm:p-3 bg-white rounded-lg">
+                        <PlayCircle className="w-4 h-4 sm:w-5 sm:h-5 text-primary flex-shrink-0" />
+                        <span className="flex-1 text-sm sm:text-base">{lesson}</span>
+                        <span className="text-xs sm:text-sm text-muted-foreground">~5 min</span>
                       </div>
                     ))}
                   </div>
-                  <button className={`px-6 py-3 ${mod.color} text-white rounded-lg hover:opacity-90 transition-opacity`}>
+                  <button className={`px-4 sm:px-6 py-2 sm:py-3 ${mod.color} text-white rounded-lg hover:opacity-90 transition-opacity text-sm sm:text-base`}>
                     {mod.completed ? 'Revisar Módulo' : 'Iniciar Módulo'}
                   </button>
                 </div>

--- a/frontend/src/app/components/Login.tsx
+++ b/frontend/src/app/components/Login.tsx
@@ -46,42 +46,42 @@ export function Login() {
   return (
     <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-50 via-yellow-50 to-red-50 p-4">
       <div className="w-full max-w-md">
-        <div className="bg-white rounded-2xl shadow-xl p-8">
-          <div className="text-center mb-8">
-            <div className="flex justify-center mb-6">
+        <div className="bg-white rounded-2xl shadow-xl p-5 sm:p-8">
+          <div className="text-center mb-6 sm:mb-8">
+            <div className="flex justify-center mb-4 sm:mb-6">
               <Logo size="cover" />
             </div>
-            <h1 className="text-3xl mb-2">Morfoblocos Digital</h1>
-            <p className="text-muted-foreground">Entre para continuar sua aprendizagem</p>
+            <h1 className="text-2xl sm:text-3xl mb-2">Morfoblocos Digital</h1>
+            <p className="text-sm sm:text-base text-muted-foreground">Entre para continuar sua aprendizagem</p>
           </div>
 
           <form onSubmit={handleSubmit} className="space-y-4">
             <div>
-              <label className="block mb-3">Tipo de Conta</label>
-              <div className="grid grid-cols-2 gap-3">
+              <label className="block mb-2 sm:mb-3 text-sm sm:text-base">Tipo de Conta</label>
+              <div className="grid grid-cols-2 gap-2 sm:gap-3">
                 <button
                   type="button"
                   onClick={() => setUserType('aluno')}
-                  className={`p-4 rounded-lg border-2 transition-all ${
+                  className={`p-3 sm:p-4 rounded-lg border-2 transition-all ${
                     userType === 'aluno'
                       ? 'border-primary bg-blue-50'
                       : 'border-border hover:border-primary/50'
                   }`}
                 >
-                  <User className="w-6 h-6 mx-auto mb-2 text-primary" />
-                  <div className="text-sm">Aluno</div>
+                  <User className="w-5 h-5 sm:w-6 sm:h-6 mx-auto mb-1 sm:mb-2 text-primary" />
+                  <div className="text-xs sm:text-sm">Aluno</div>
                 </button>
                 <button
                   type="button"
                   onClick={() => setUserType('professor')}
-                  className={`p-4 rounded-lg border-2 transition-all ${
+                  className={`p-3 sm:p-4 rounded-lg border-2 transition-all ${
                     userType === 'professor'
                       ? 'border-primary bg-blue-50'
                       : 'border-border hover:border-primary/50'
                   }`}
                 >
-                  <GraduationCap className="w-6 h-6 mx-auto mb-2 text-primary" />
-                  <div className="text-sm">Professor</div>
+                  <GraduationCap className="w-5 h-5 sm:w-6 sm:h-6 mx-auto mb-1 sm:mb-2 text-primary" />
+                  <div className="text-xs sm:text-sm">Professor</div>
                 </button>
               </div>
             </div>

--- a/frontend/src/app/components/ProfessorDashboard.tsx
+++ b/frontend/src/app/components/ProfessorDashboard.tsx
@@ -87,35 +87,35 @@ export function ProfessorDashboard() {
   return (
     <div className="min-h-screen bg-gradient-to-br from-blue-50 via-yellow-50 to-red-50">
       <header className="bg-white/90 backdrop-blur border-b border-border sticky top-0 z-10">
-        <div className="max-w-7xl mx-auto px-4 py-4 flex items-center justify-between">
-          <div className="flex items-center gap-3">
-            <Logo size="md" />
-            <div>
-              <h1 className="text-2xl">Morfoblocos Digital</h1>
-              <div className="text-sm text-muted-foreground">Painel do Professor</div>
+        <div className="max-w-7xl mx-auto px-3 sm:px-4 py-3 sm:py-4 flex items-center justify-between">
+          <div className="flex items-center gap-2 sm:gap-3 min-w-0">
+            <Logo size="sm" />
+            <div className="min-w-0">
+              <h1 className="text-lg sm:text-2xl truncate">Morfoblocos Digital</h1>
+              <div className="text-xs sm:text-sm text-muted-foreground">Painel do Professor</div>
             </div>
           </div>
-          <div className="flex items-center gap-4">
+          <div className="flex items-center gap-2 sm:gap-4 shrink-0">
             <div className="text-right hidden sm:block">
               <div className="text-sm text-muted-foreground">Prof.</div>
               <div>Carlos Mendes</div>
             </div>
-            <div className="w-10 h-10 bg-gradient-to-br from-blue-600 to-blue-700 rounded-full flex items-center justify-center text-white shadow">
-              <User className="w-5 h-5" />
+            <div className="w-8 h-8 sm:w-10 sm:h-10 bg-gradient-to-br from-blue-600 to-blue-700 rounded-full flex items-center justify-center text-white shadow">
+              <User className="w-4 h-4 sm:w-5 sm:h-5" />
             </div>
             <Link to="/login" className="text-muted-foreground hover:text-foreground">
-              <LogOut className="w-5 h-5" />
+              <LogOut className="w-4 h-4 sm:w-5 sm:h-5" />
             </Link>
           </div>
         </div>
       </header>
 
-      <main className="max-w-7xl mx-auto px-4 py-8">
+      <main className="max-w-7xl mx-auto px-3 sm:px-4 py-4 sm:py-8">
         {/* Seletor de Turma + Ações */}
-        <div className="bg-white rounded-2xl shadow-lg p-5 mb-6 flex flex-col md:flex-row gap-4 md:items-center md:justify-between">
-          <div className="flex items-center gap-3 flex-wrap">
-            <GraduationCap className="w-6 h-6 text-blue-600" />
-            <span className="text-muted-foreground">Turma selecionada:</span>
+        <div className="bg-white rounded-xl sm:rounded-2xl shadow-lg p-3 sm:p-5 mb-4 sm:mb-6 flex flex-col gap-3 sm:gap-4 md:flex-row md:items-center md:justify-between">
+          <div className="flex items-center gap-2 sm:gap-3 flex-wrap">
+            <GraduationCap className="w-5 h-5 sm:w-6 sm:h-6 text-blue-600" />
+            <span className="text-sm sm:text-base text-muted-foreground">Turma selecionada:</span>
             {myTurmas.length === 0 ? (
               <span className="text-muted-foreground italic">Nenhuma turma criada</span>
             ) : (
@@ -139,16 +139,16 @@ export function ProfessorDashboard() {
           <div className="flex gap-2">
             <button
               onClick={() => setShowTurmaModal(true)}
-              className="px-4 py-2 bg-yellow-400 text-white rounded-xl hover:bg-yellow-500 transition-colors flex items-center gap-2 shadow-md"
+              className="px-3 sm:px-4 py-2 bg-yellow-400 text-white rounded-xl hover:bg-yellow-500 transition-colors flex items-center gap-1.5 sm:gap-2 shadow-md text-sm sm:text-base"
             >
-              <Plus className="w-4 h-4" /> Nova Turma
+              <Plus className="w-4 h-4" /> <span className="hidden xs:inline">Nova</span> Turma
             </button>
             <button
               onClick={() => { setAlunoClassId(selectedClassId); setShowAlunoModal(true); }}
               disabled={myTurmas.length === 0}
-              className="px-4 py-2 bg-blue-600 text-white rounded-xl hover:bg-blue-700 transition-colors flex items-center gap-2 shadow-md disabled:opacity-50"
+              className="px-3 sm:px-4 py-2 bg-blue-600 text-white rounded-xl hover:bg-blue-700 transition-colors flex items-center gap-1.5 sm:gap-2 shadow-md disabled:opacity-50 text-sm sm:text-base"
             >
-              <Plus className="w-4 h-4" /> Cadastrar Aluno
+              <Plus className="w-4 h-4" /> <span className="hidden sm:inline">Cadastrar</span> Aluno
             </button>
           </div>
         </div>
@@ -156,21 +156,21 @@ export function ProfessorDashboard() {
         {selectedClassId ? (
           <>
             {/* Stats */}
-            <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
+            <div className="grid grid-cols-2 lg:grid-cols-4 gap-2 sm:gap-4 mb-4 sm:mb-8">
               {[
                 { icon: Users, label: 'Alunos na Turma', value: String(totalStudents), bg: 'bg-blue-100', text: 'text-blue-600', border: 'border-blue-600' },
                 { icon: TrendingUp, label: 'Média da Turma', value: `${avgPct}%`, bg: 'bg-yellow-100', text: 'text-yellow-600', border: 'border-yellow-400' },
                 { icon: Award, label: 'Alto Desempenho', value: String(concluidos), bg: 'bg-green-100', text: 'text-green-600', border: 'border-green-500' },
                 { icon: AlertCircle, label: 'Precisam Ajuda', value: String(precisamAjuda), bg: 'bg-red-100', text: 'text-red-600', border: 'border-red-500' },
               ].map((stat, i) => (
-                <div key={i} className={`bg-white rounded-2xl p-5 shadow-lg border-l-4 ${stat.border} hover:shadow-xl transition-shadow`}>
-                  <div className="flex items-center justify-between">
-                    <div>
-                      <div className="text-sm text-muted-foreground mb-1">{stat.label}</div>
-                      <div className="text-3xl">{stat.value}</div>
+                <div key={i} className={`bg-white rounded-xl sm:rounded-2xl p-3 sm:p-5 shadow-lg border-l-4 ${stat.border} hover:shadow-xl transition-shadow`}>
+                  <div className="flex items-center justify-between gap-2">
+                    <div className="min-w-0">
+                      <div className="text-xs sm:text-sm text-muted-foreground mb-1 truncate">{stat.label}</div>
+                      <div className="text-xl sm:text-3xl">{stat.value}</div>
                     </div>
-                    <div className={`w-12 h-12 ${stat.bg} rounded-full flex items-center justify-center`}>
-                      <stat.icon className={`w-6 h-6 ${stat.text}`} />
+                    <div className={`w-9 h-9 sm:w-12 sm:h-12 ${stat.bg} rounded-full flex items-center justify-center shrink-0`}>
+                      <stat.icon className={`w-4 h-4 sm:w-6 sm:h-6 ${stat.text}`} />
                     </div>
                   </div>
                 </div>
@@ -178,15 +178,15 @@ export function ProfessorDashboard() {
             </div>
 
             {/* Gráficos */}
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-8">
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-3 sm:gap-6 mb-4 sm:mb-8">
               {/* Gráfico de erros — destaque para o que mais erram */}
-              <div className="bg-white rounded-2xl p-6 shadow-lg lg:col-span-2">
-                <div className="flex items-center justify-between mb-4">
+              <div className="bg-white rounded-xl sm:rounded-2xl p-3 sm:p-6 shadow-lg lg:col-span-2">
+                <div className="flex flex-col sm:flex-row sm:items-center justify-between mb-3 sm:mb-4 gap-2">
                   <div>
-                    <h3 className="text-xl">Onde os alunos mais erram</h3>
-                    <p className="text-sm text-muted-foreground">Tópicos ordenados pelo número de erros</p>
+                    <h3 className="text-base sm:text-xl">Onde os alunos mais erram</h3>
+                    <p className="text-xs sm:text-sm text-muted-foreground">Tópicos ordenados pelo número de erros</p>
                   </div>
-                  <div className="px-3 py-1 bg-red-100 text-red-700 rounded-full text-sm">
+                  <div className="px-2 sm:px-3 py-1 bg-red-100 text-red-700 rounded-full text-xs sm:text-sm self-start sm:self-auto">
                     Foco em revisão
                   </div>
                 </div>
@@ -195,8 +195,8 @@ export function ProfessorDashboard() {
                     Esta turma ainda não respondeu nenhuma questão.
                   </div>
                 ) : (
-                  <ResponsiveContainer width="100%" height={300}>
-                    <BarChart data={errorsByTopic} layout="vertical" margin={{ left: 20 }}>
+                  <ResponsiveContainer width="100%" height={250}>
+                    <BarChart data={errorsByTopic} layout="vertical" margin={{ left: 0, right: 10 }}>
                       <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" />
                       <XAxis type="number" />
                       <YAxis type="category" dataKey="topico" width={100} />
@@ -215,12 +215,12 @@ export function ProfessorDashboard() {
                 )}
               </div>
 
-              <div className="bg-white rounded-2xl p-6 shadow-lg">
-                <h3 className="text-xl mb-4">Evolução por Data</h3>
+              <div className="bg-white rounded-xl sm:rounded-2xl p-3 sm:p-6 shadow-lg">
+                <h3 className="text-base sm:text-xl mb-3 sm:mb-4">Evolução por Data</h3>
                 {evolutionData.length === 0 ? (
-                  <div className="text-center text-muted-foreground py-12">Sem dados ainda</div>
+                  <div className="text-center text-muted-foreground py-8 sm:py-12 text-sm">Sem dados ainda</div>
                 ) : (
-                  <ResponsiveContainer width="100%" height={260}>
+                  <ResponsiveContainer width="100%" height={220}>
                     <LineChart data={evolutionData}>
                       <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" />
                       <XAxis dataKey="date" />
@@ -234,8 +234,8 @@ export function ProfessorDashboard() {
                 )}
               </div>
 
-              <div className="bg-gradient-to-br from-blue-600 to-blue-700 text-white rounded-2xl p-6 shadow-lg">
-                <h3 className="text-xl mb-4">Resumo da Turma</h3>
+              <div className="bg-gradient-to-br from-blue-600 to-blue-700 text-white rounded-xl sm:rounded-2xl p-4 sm:p-6 shadow-lg">
+                <h3 className="text-base sm:text-xl mb-3 sm:mb-4">Resumo da Turma</h3>
                 <div className="space-y-4">
                   <div>
                     <div className="flex justify-between mb-1"><span>Questões respondidas</span><span>{totalAnswers}</span></div>
@@ -259,80 +259,120 @@ export function ProfessorDashboard() {
             </div>
 
             {/* Lista de alunos */}
-            <div className="bg-white rounded-2xl shadow-lg p-6">
-              <h3 className="text-xl mb-4">Acompanhamento dos Alunos</h3>
+            <div className="bg-white rounded-xl sm:rounded-2xl shadow-lg p-3 sm:p-6">
+              <h3 className="text-base sm:text-xl mb-3 sm:mb-4">Acompanhamento dos Alunos</h3>
               {classStudents.length === 0 ? (
-                <div className="text-center text-muted-foreground py-8">
+                <div className="text-center text-muted-foreground py-6 sm:py-8 text-sm">
                   Nenhum aluno cadastrado nesta turma. Use o botão "Cadastrar Aluno".
                 </div>
               ) : (
-                <div className="overflow-x-auto">
-                  <table className="w-full">
-                    <thead>
-                      <tr className="border-b border-border text-left text-sm text-muted-foreground">
-                        <th className="pb-3">Aluno</th>
-                        <th className="pb-3">Respondidas</th>
-                        <th className="pb-3">Aproveitamento</th>
-                        <th className="pb-3">Status</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {classStudents.map((s) => {
-                        const sh = classHistory.filter((h) => h.studentId === s.id);
-                        const total = sh.length;
-                        const c = sh.filter((h) => h.correct).length;
-                        const pct = total ? Math.round((c / total) * 100) : 0;
-                        let status = 'Sem dados', color = 'bg-gray-200 text-gray-700', barColor = 'bg-gray-400';
-                        if (total > 0) {
-                          if (pct >= 80) { status = 'Excelente'; color = 'bg-blue-100 text-blue-700'; barColor = 'bg-blue-600'; }
-                          else if (pct >= 65) { status = 'Bom'; color = 'bg-yellow-100 text-yellow-700'; barColor = 'bg-yellow-500'; }
-                          else if (pct >= 50) { status = 'Regular'; color = 'bg-orange-100 text-orange-700'; barColor = 'bg-orange-500'; }
-                          else { status = 'Precisa Ajuda'; color = 'bg-red-100 text-red-700'; barColor = 'bg-red-500'; }
-                        }
-                        return (
-                          <tr key={s.id} className="border-b border-border last:border-0">
-                            <td className="py-4">
-                              <div className="flex items-center gap-3">
-                                <div className={`w-10 h-10 ${barColor} rounded-full flex items-center justify-center text-white`}>
-                                  {s.name.charAt(0)}
+                <>
+                  {/* Mobile: cards */}
+                  <div className="sm:hidden space-y-3">
+                    {classStudents.map((s) => {
+                      const sh = classHistory.filter((h) => h.studentId === s.id);
+                      const total = sh.length;
+                      const c = sh.filter((h) => h.correct).length;
+                      const pct = total ? Math.round((c / total) * 100) : 0;
+                      let status = 'Sem dados', color = 'bg-gray-200 text-gray-700', barColor = 'bg-gray-400';
+                      if (total > 0) {
+                        if (pct >= 80) { status = 'Excelente'; color = 'bg-blue-100 text-blue-700'; barColor = 'bg-blue-600'; }
+                        else if (pct >= 65) { status = 'Bom'; color = 'bg-yellow-100 text-yellow-700'; barColor = 'bg-yellow-500'; }
+                        else if (pct >= 50) { status = 'Regular'; color = 'bg-orange-100 text-orange-700'; barColor = 'bg-orange-500'; }
+                        else { status = 'Precisa Ajuda'; color = 'bg-red-100 text-red-700'; barColor = 'bg-red-500'; }
+                      }
+                      return (
+                        <div key={s.id} className="border border-border rounded-xl p-3">
+                          <div className="flex items-center gap-3 mb-2">
+                            <div className={`w-9 h-9 ${barColor} rounded-full flex items-center justify-center text-white text-sm`}>
+                              {s.name.charAt(0)}
+                            </div>
+                            <div className="min-w-0 flex-1">
+                              <div className="text-sm truncate">{s.name}</div>
+                              <div className="text-xs text-muted-foreground truncate">{s.email}</div>
+                            </div>
+                            <span className={`text-xs px-2 py-0.5 rounded-full shrink-0 ${color}`}>{status}</span>
+                          </div>
+                          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                            <span>{total} resp.</span>
+                            <div className="flex-1 bg-gray-200 rounded-full h-1.5 overflow-hidden">
+                              <div className={`${barColor} h-full`} style={{ width: `${pct}%` }} />
+                            </div>
+                            <span>{pct}%</span>
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                  {/* Desktop: tabela */}
+                  <div className="hidden sm:block overflow-x-auto">
+                    <table className="w-full">
+                      <thead>
+                        <tr className="border-b border-border text-left text-sm text-muted-foreground">
+                          <th className="pb-3">Aluno</th>
+                          <th className="pb-3">Respondidas</th>
+                          <th className="pb-3">Aproveitamento</th>
+                          <th className="pb-3">Status</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {classStudents.map((s) => {
+                          const sh = classHistory.filter((h) => h.studentId === s.id);
+                          const total = sh.length;
+                          const c = sh.filter((h) => h.correct).length;
+                          const pct = total ? Math.round((c / total) * 100) : 0;
+                          let status = 'Sem dados', color = 'bg-gray-200 text-gray-700', barColor = 'bg-gray-400';
+                          if (total > 0) {
+                            if (pct >= 80) { status = 'Excelente'; color = 'bg-blue-100 text-blue-700'; barColor = 'bg-blue-600'; }
+                            else if (pct >= 65) { status = 'Bom'; color = 'bg-yellow-100 text-yellow-700'; barColor = 'bg-yellow-500'; }
+                            else if (pct >= 50) { status = 'Regular'; color = 'bg-orange-100 text-orange-700'; barColor = 'bg-orange-500'; }
+                            else { status = 'Precisa Ajuda'; color = 'bg-red-100 text-red-700'; barColor = 'bg-red-500'; }
+                          }
+                          return (
+                            <tr key={s.id} className="border-b border-border last:border-0">
+                              <td className="py-4">
+                                <div className="flex items-center gap-3">
+                                  <div className={`w-10 h-10 ${barColor} rounded-full flex items-center justify-center text-white`}>
+                                    {s.name.charAt(0)}
+                                  </div>
+                                  <div>
+                                    <div>{s.name}</div>
+                                    <div className="text-xs text-muted-foreground">{s.email}</div>
+                                  </div>
                                 </div>
-                                <div>
-                                  <div>{s.name}</div>
-                                  <div className="text-xs text-muted-foreground">{s.email}</div>
+                              </td>
+                              <td className="py-4">{total}</td>
+                              <td className="py-4">
+                                <div className="flex items-center gap-3 min-w-40">
+                                  <div className="flex-1 bg-gray-200 rounded-full h-2 overflow-hidden">
+                                    <div className={`${barColor} h-full`} style={{ width: `${pct}%` }} />
+                                  </div>
+                                  <span className="text-sm w-10">{pct}%</span>
                                 </div>
-                              </div>
-                            </td>
-                            <td className="py-4">{total}</td>
-                            <td className="py-4">
-                              <div className="flex items-center gap-3 min-w-40">
-                                <div className="flex-1 bg-gray-200 rounded-full h-2 overflow-hidden">
-                                  <div className={`${barColor} h-full`} style={{ width: `${pct}%` }} />
-                                </div>
-                                <span className="text-sm w-10">{pct}%</span>
-                              </div>
-                            </td>
-                            <td className="py-4">
-                              <span className={`text-xs px-3 py-1 rounded-full ${color}`}>{status}</span>
-                            </td>
-                          </tr>
-                        );
-                      })}
-                    </tbody>
-                  </table>
-                </div>
+                              </td>
+                              <td className="py-4">
+                                <span className={`text-xs px-3 py-1 rounded-full ${color}`}>{status}</span>
+                              </td>
+                            </tr>
+                          );
+                        })}
+                      </tbody>
+                    </table>
+                  </div>
+                </>
               )}
             </div>
           </>
         ) : (
-          <div className="bg-white rounded-2xl shadow-lg p-12 text-center">
-            <GraduationCap className="w-16 h-16 text-blue-600 mx-auto mb-4" />
-            <h3 className="text-xl mb-2">Crie sua primeira turma</h3>
-            <p className="text-muted-foreground mb-6">
+          <div className="bg-white rounded-xl sm:rounded-2xl shadow-lg p-8 sm:p-12 text-center">
+            <GraduationCap className="w-12 h-12 sm:w-16 sm:h-16 text-blue-600 mx-auto mb-3 sm:mb-4" />
+            <h3 className="text-lg sm:text-xl mb-2">Crie sua primeira turma</h3>
+            <p className="text-sm sm:text-base text-muted-foreground mb-4 sm:mb-6">
               Você ainda não tem turmas. Clique em "Nova Turma" para começar.
             </p>
             <button
               onClick={() => setShowTurmaModal(true)}
-              className="px-6 py-3 bg-blue-600 text-white rounded-xl hover:bg-blue-700 transition-colors inline-flex items-center gap-2"
+              className="px-5 sm:px-6 py-3 bg-blue-600 text-white rounded-xl hover:bg-blue-700 transition-colors inline-flex items-center gap-2 text-sm sm:text-base"
             >
               <Plus className="w-5 h-5" /> Criar Turma
             </button>
@@ -422,10 +462,10 @@ export function ProfessorDashboard() {
 
 function Modal({ title, onClose, children }: { title: string; onClose: () => void; children: React.ReactNode }) {
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50" onClick={onClose}>
-      <div className="bg-white rounded-2xl shadow-2xl p-6 max-w-md w-full" onClick={(e) => e.stopPropagation()}>
+    <div className="fixed inset-0 bg-black/50 flex items-end sm:items-center justify-center sm:p-4 z-50" onClick={onClose}>
+      <div className="bg-white rounded-t-2xl sm:rounded-2xl shadow-2xl p-5 sm:p-6 max-w-md w-full max-h-[90vh] overflow-y-auto" onClick={(e) => e.stopPropagation()}>
         <div className="flex items-center justify-between mb-4">
-          <h3 className="text-xl">{title}</h3>
+          <h3 className="text-lg sm:text-xl">{title}</h3>
           <button onClick={onClose} className="text-muted-foreground hover:text-foreground">
             <X className="w-5 h-5" />
           </button>

--- a/frontend/src/app/components/QuestionsScreen.tsx
+++ b/frontend/src/app/components/QuestionsScreen.tsx
@@ -126,16 +126,16 @@ export function QuestionsScreen() {
     const pct = (score / questions.length) * 100;
     const unlockedLevel2 = level === 1 && pct >= 80;
     return (
-      <div className="min-h-screen bg-gradient-to-br from-blue-50 via-yellow-50 to-red-50 flex items-center justify-center p-4">
-        <div className="bg-white rounded-3xl shadow-2xl p-8 max-w-md w-full text-center">
-          <div className="w-24 h-24 bg-gradient-to-br from-yellow-400 to-yellow-500 rounded-full flex items-center justify-center mx-auto mb-6 shadow-xl">
-            <Trophy className="w-12 h-12 text-white" />
+      <div className="min-h-screen bg-gradient-to-br from-blue-50 via-yellow-50 to-red-50 flex items-center justify-center p-3 sm:p-4">
+        <div className="bg-white rounded-2xl sm:rounded-3xl shadow-2xl p-5 sm:p-8 max-w-md w-full text-center">
+          <div className="w-18 h-18 sm:w-24 sm:h-24 bg-gradient-to-br from-yellow-400 to-yellow-500 rounded-full flex items-center justify-center mx-auto mb-4 sm:mb-6 shadow-xl" style={{ width: 'clamp(4.5rem, 15vw, 6rem)', height: 'clamp(4.5rem, 15vw, 6rem)' }}>
+            <Trophy className="w-8 h-8 sm:w-12 sm:h-12 text-white" />
           </div>
-          <h2 className="text-3xl mb-2">Parabéns!</h2>
-          <p className="text-muted-foreground mb-6">Você concluiu o Nível {level}</p>
-          <div className="bg-gradient-to-br from-blue-50 to-yellow-50 rounded-2xl p-6 mb-6">
-            <div className="text-5xl text-blue-600 mb-2">{score}/{questions.length}</div>
-            <div className="text-muted-foreground">acertos ({pct.toFixed(0)}%)</div>
+          <h2 className="text-2xl sm:text-3xl mb-2">Parabéns!</h2>
+          <p className="text-sm sm:text-base text-muted-foreground mb-4 sm:mb-6">Você concluiu o Nível {level}</p>
+          <div className="bg-gradient-to-br from-blue-50 to-yellow-50 rounded-xl sm:rounded-2xl p-4 sm:p-6 mb-4 sm:mb-6">
+            <div className="text-4xl sm:text-5xl text-blue-600 mb-2">{score}/{questions.length}</div>
+            <div className="text-sm sm:text-base text-muted-foreground">acertos ({pct.toFixed(0)}%)</div>
           </div>
           {unlockedLevel2 && (
             <div className="bg-gradient-to-r from-yellow-100 to-red-100 border-2 border-yellow-400 rounded-2xl p-4 mb-4">
@@ -188,47 +188,47 @@ export function QuestionsScreen() {
   const isCorrect = selected === q.correct;
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-yellow-50 to-red-50 p-4">
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-yellow-50 to-red-50 p-3 sm:p-4">
       <div className="max-w-3xl mx-auto">
-        <div className="flex items-center justify-between mb-6">
-          <Link to="/aluno/dashboard" className="flex items-center gap-2 text-muted-foreground hover:text-foreground">
-            <ArrowLeft className="w-5 h-5" /> Voltar
+        <div className="flex items-center justify-between mb-4 sm:mb-6 gap-2">
+          <Link to="/aluno/dashboard" className="flex items-center gap-1 sm:gap-2 text-muted-foreground hover:text-foreground shrink-0">
+            <ArrowLeft className="w-5 h-5" /> <span className="hidden sm:inline">Voltar</span>
           </Link>
-          <div className="flex items-center gap-3 text-sm">
+          <div className="flex items-center gap-2 sm:gap-3 text-sm">
             <div className="flex rounded-full overflow-hidden border border-border bg-white shadow-sm">
               <button
                 onClick={() => reset(1)}
-                className={`px-3 py-1 transition-colors ${level === 1 ? 'bg-blue-100 text-blue-700' : 'text-muted-foreground hover:bg-blue-50'}`}
+                className={`px-2 sm:px-3 py-1 transition-colors text-xs sm:text-sm ${level === 1 ? 'bg-blue-100 text-blue-700' : 'text-muted-foreground hover:bg-blue-50'}`}
               >
                 Nível 1
               </button>
               <button
                 onClick={() => reset(2)}
-                className={`px-3 py-1 transition-colors ${level === 2 ? 'bg-red-100 text-red-700' : 'text-muted-foreground hover:bg-red-50'}`}
+                className={`px-2 sm:px-3 py-1 transition-colors text-xs sm:text-sm ${level === 2 ? 'bg-red-100 text-red-700' : 'text-muted-foreground hover:bg-red-50'}`}
               >
                 Nível 2
               </button>
             </div>
-            <span className="text-muted-foreground">
-              Pergunta {current + 1} de {questions.length}
+            <span className="text-xs sm:text-sm text-muted-foreground whitespace-nowrap">
+              {current + 1}/{questions.length}
             </span>
           </div>
         </div>
 
-        <div className="bg-white/60 rounded-full h-2 overflow-hidden mb-8 shadow-inner">
+        <div className="bg-white/60 rounded-full h-2 overflow-hidden mb-4 sm:mb-8 shadow-inner">
           <div
             className="bg-gradient-to-r from-blue-600 to-yellow-400 h-full transition-all"
             style={{ width: `${((current + 1) / questions.length) * 100}%` }}
           />
         </div>
 
-        <div className="bg-white rounded-3xl shadow-2xl p-8">
-          <div className="inline-block px-3 py-1 bg-gradient-to-r from-blue-100 to-yellow-100 text-blue-700 rounded-full text-sm mb-4">
+        <div className="bg-white rounded-2xl sm:rounded-3xl shadow-2xl p-4 sm:p-8">
+          <div className="inline-block px-2 sm:px-3 py-1 bg-gradient-to-r from-blue-100 to-yellow-100 text-blue-700 rounded-full text-xs sm:text-sm mb-3 sm:mb-4">
             {q.topic}
           </div>
-          <h2 className="text-2xl mb-8">{q.question}</h2>
+          <h2 className="text-lg sm:text-2xl mb-4 sm:mb-8">{q.question}</h2>
 
-          <div className="space-y-3">
+          <div className="space-y-2 sm:space-y-3">
             {q.options.map((option, idx) => {
               const isSel = selected === idx;
               const isAns = idx === q.correct;
@@ -242,7 +242,7 @@ export function QuestionsScreen() {
                   key={idx}
                   onClick={() => handleSelect(idx)}
                   disabled={showResult}
-                  className={`w-full p-4 rounded-xl border-2 text-left transition-all flex items-center justify-between ${style}`}
+                  className={`w-full p-3 sm:p-4 rounded-xl border-2 text-left transition-all flex items-center justify-between text-sm sm:text-base ${style}`}
                 >
                   <span>{option}</span>
                   {showResult && isAns && <Check className="w-5 h-5 text-green-600" />}
@@ -253,7 +253,7 @@ export function QuestionsScreen() {
           </div>
 
           {showResult && (
-            <div className={`mt-6 p-5 rounded-2xl border-l-4 ${isCorrect ? 'bg-green-50 border-green-500' : 'bg-red-50 border-red-500'}`}>
+            <div className={`mt-4 sm:mt-6 p-3 sm:p-5 rounded-xl sm:rounded-2xl border-l-4 ${isCorrect ? 'bg-green-50 border-green-500' : 'bg-red-50 border-red-500'}`}>
               <div className="flex items-center gap-2 mb-2">
                 {isCorrect ? (
                   <>

--- a/frontend/src/app/components/Register.tsx
+++ b/frontend/src/app/components/Register.tsx
@@ -53,40 +53,40 @@ export function Register() {
   return (
     <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-50 via-yellow-50 to-red-50 p-4">
       <div className="w-full max-w-md">
-        <div className="bg-white rounded-2xl shadow-xl p-8">
-          <div className="text-center mb-8">
-            <div className="flex justify-center mb-6"><Logo size="cover" /></div>
-            <h1 className="text-3xl mb-2">Criar Conta</h1>
-            <p className="text-muted-foreground">Junte-se ao Morfoblocos Digital</p>
+        <div className="bg-white rounded-2xl shadow-xl p-5 sm:p-8">
+          <div className="text-center mb-6 sm:mb-8">
+            <div className="flex justify-center mb-4 sm:mb-6"><Logo size="cover" /></div>
+            <h1 className="text-2xl sm:text-3xl mb-2">Criar Conta</h1>
+            <p className="text-sm sm:text-base text-muted-foreground">Junte-se ao Morfoblocos Digital</p>
           </div>
 
           <form onSubmit={handleSubmit} className="space-y-4">
             <div>
-              <label className="block mb-3">Tipo de Conta</label>
-              <div className="grid grid-cols-2 gap-3">
+              <label className="block mb-2 sm:mb-3 text-sm sm:text-base">Tipo de Conta</label>
+              <div className="grid grid-cols-2 gap-2 sm:gap-3">
                 <button
                   type="button"
                   onClick={() => setUserType('aluno')}
-                  className={`p-4 rounded-lg border-2 transition-all ${
+                  className={`p-3 sm:p-4 rounded-lg border-2 transition-all ${
                     userType === 'aluno'
                       ? 'border-primary bg-blue-50'
                       : 'border-border hover:border-primary/50'
                   }`}
                 >
-                  <User className="w-6 h-6 mx-auto mb-2 text-primary" />
-                  <div className="text-sm">Aluno</div>
+                  <User className="w-5 h-5 sm:w-6 sm:h-6 mx-auto mb-1 sm:mb-2 text-primary" />
+                  <div className="text-xs sm:text-sm">Aluno</div>
                 </button>
                 <button
                   type="button"
                   onClick={() => setUserType('professor')}
-                  className={`p-4 rounded-lg border-2 transition-all ${
+                  className={`p-3 sm:p-4 rounded-lg border-2 transition-all ${
                     userType === 'professor'
                       ? 'border-primary bg-blue-50'
                       : 'border-border hover:border-primary/50'
                   }`}
                 >
-                  <GraduationCap className="w-6 h-6 mx-auto mb-2 text-primary" />
-                  <div className="text-sm">Professor</div>
+                  <GraduationCap className="w-5 h-5 sm:w-6 sm:h-6 mx-auto mb-1 sm:mb-2 text-primary" />
+                  <div className="text-xs sm:text-sm">Professor</div>
                 </button>
               </div>
             </div>

--- a/frontend/src/app/components/StudentDashboard.tsx
+++ b/frontend/src/app/components/StudentDashboard.tsx
@@ -19,117 +19,125 @@ export function StudentDashboard() {
   return (
     <div className="min-h-screen bg-gradient-to-br from-blue-50 via-yellow-50 to-red-50">
       <header className="bg-white/90 backdrop-blur border-b border-border sticky top-0 z-10">
-        <div className="max-w-7xl mx-auto px-4 py-4 flex items-center justify-between">
-          <div className="flex items-center gap-3">
-            <Logo size="md" />
-            <h1 className="text-2xl">Morfoblocos Digital</h1>
+        <div className="max-w-7xl mx-auto px-3 sm:px-4 py-3 sm:py-4 flex items-center justify-between">
+          <div className="flex items-center gap-2 sm:gap-3 min-w-0">
+            <Logo size="sm" />
+            <h1 className="text-lg sm:text-2xl truncate">Morfoblocos Digital</h1>
           </div>
-          <div className="flex items-center gap-4">
+          <div className="flex items-center gap-2 sm:gap-4 shrink-0">
             <div className="text-right hidden sm:block">
               <div className="text-sm text-muted-foreground">Olá,</div>
               <div>{studentName}</div>
             </div>
-            <div className="w-10 h-10 bg-gradient-to-br from-blue-600 to-blue-700 rounded-full flex items-center justify-center text-white shadow">
-              <User className="w-5 h-5" />
+            <div className="w-8 h-8 sm:w-10 sm:h-10 bg-gradient-to-br from-blue-600 to-blue-700 rounded-full flex items-center justify-center text-white shadow">
+              <User className="w-4 h-4 sm:w-5 sm:h-5" />
             </div>
             <Link to="/login" className="text-muted-foreground hover:text-foreground">
-              <LogOut className="w-5 h-5" />
+              <LogOut className="w-4 h-4 sm:w-5 sm:h-5" />
             </Link>
           </div>
         </div>
       </header>
 
-      <main className="max-w-7xl mx-auto px-4 py-8">
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
-          <div className="bg-white rounded-2xl p-6 shadow-lg border-l-4 border-blue-600 hover:shadow-xl transition-shadow">
+      <main className="max-w-7xl mx-auto px-3 sm:px-4 py-4 sm:py-8">
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 sm:gap-6 mb-4 sm:mb-8">
+          <div className="bg-white rounded-xl sm:rounded-2xl p-4 sm:p-6 shadow-lg border-l-4 border-blue-600 hover:shadow-xl transition-shadow">
             <div className="flex items-center justify-between">
               <div>
-                <div className="text-sm text-muted-foreground mb-1">Nível Atual</div>
-                <div className="text-3xl">Nível {level}</div>
+                <div className="text-xs sm:text-sm text-muted-foreground mb-1">Nível Atual</div>
+                <div className="text-2xl sm:text-3xl">Nível {level}</div>
               </div>
-              <div className="w-14 h-14 bg-blue-100 rounded-full flex items-center justify-center">
-                <Trophy className="w-7 h-7 text-blue-600" />
+              <div className="w-10 h-10 sm:w-14 sm:h-14 bg-blue-100 rounded-full flex items-center justify-center">
+                <Trophy className="w-5 h-5 sm:w-7 sm:h-7 text-blue-600" />
               </div>
             </div>
           </div>
 
-          <div className="bg-white rounded-2xl p-6 shadow-lg border-l-4 border-yellow-400 hover:shadow-xl transition-shadow">
+          <div className="bg-white rounded-xl sm:rounded-2xl p-4 sm:p-6 shadow-lg border-l-4 border-yellow-400 hover:shadow-xl transition-shadow">
             <div className="flex items-center justify-between">
               <div>
-                <div className="text-sm text-muted-foreground mb-1">Pontos</div>
-                <div className="text-3xl">{points}</div>
+                <div className="text-xs sm:text-sm text-muted-foreground mb-1">Pontos</div>
+                <div className="text-2xl sm:text-3xl">{points}</div>
               </div>
-              <div className="w-14 h-14 bg-yellow-100 rounded-full flex items-center justify-center">
-                <Trophy className="w-7 h-7 text-yellow-600" />
+              <div className="w-10 h-10 sm:w-14 sm:h-14 bg-yellow-100 rounded-full flex items-center justify-center">
+                <Trophy className="w-5 h-5 sm:w-7 sm:h-7 text-yellow-600" />
               </div>
             </div>
           </div>
 
-          <div className="bg-white rounded-2xl p-6 shadow-lg border-l-4 border-red-500 hover:shadow-xl transition-shadow">
+          <div className="bg-white rounded-xl sm:rounded-2xl p-4 sm:p-6 shadow-lg border-l-4 border-red-500 hover:shadow-xl transition-shadow">
             <div className="flex items-center justify-between">
               <div>
-                <div className="text-sm text-muted-foreground mb-1">Aproveitamento</div>
-                <div className="text-3xl">{progress}%</div>
+                <div className="text-xs sm:text-sm text-muted-foreground mb-1">Aproveitamento</div>
+                <div className="text-2xl sm:text-3xl">{progress}%</div>
               </div>
-              <div className="w-14 h-14 bg-red-100 rounded-full flex items-center justify-center">
-                <Brain className="w-7 h-7 text-red-600" />
+              <div className="w-10 h-10 sm:w-14 sm:h-14 bg-red-100 rounded-full flex items-center justify-center">
+                <Brain className="w-5 h-5 sm:w-7 sm:h-7 text-red-600" />
               </div>
             </div>
-            <div className="mt-4 bg-gray-200 rounded-full h-2 overflow-hidden">
+            <div className="mt-3 sm:mt-4 bg-gray-200 rounded-full h-2 overflow-hidden">
               <div className="bg-gradient-to-r from-red-500 to-yellow-400 h-full" style={{ width: `${progress}%` }} />
             </div>
           </div>
         </div>
 
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-          <div className="lg:col-span-2 grid grid-cols-1 md:grid-cols-2 gap-6">
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-3 sm:gap-6">
+          <div className="lg:col-span-2 grid grid-cols-1 sm:grid-cols-2 gap-3 sm:gap-6">
             <Link
               to="/aluno/perguntas"
-              className="bg-white rounded-2xl p-6 shadow-lg hover:shadow-2xl hover:-translate-y-1 transition-all group border-2 border-transparent hover:border-blue-600"
+              className="bg-white rounded-xl sm:rounded-2xl p-4 sm:p-6 shadow-lg hover:shadow-2xl hover:-translate-y-1 transition-all group border-2 border-transparent hover:border-blue-600"
             >
-              <div className="w-14 h-14 bg-gradient-to-br from-blue-600 to-blue-700 rounded-2xl flex items-center justify-center mb-4 group-hover:scale-110 transition-transform">
-                <BookOpen className="w-7 h-7 text-white" />
+              <div className="flex sm:block items-center gap-3">
+                <div className="w-10 h-10 sm:w-14 sm:h-14 bg-gradient-to-br from-blue-600 to-blue-700 rounded-xl sm:rounded-2xl flex items-center justify-center sm:mb-4 group-hover:scale-110 transition-transform shrink-0">
+                  <BookOpen className="w-5 h-5 sm:w-7 sm:h-7 text-white" />
+                </div>
+                <div>
+                  <h2 className="text-base sm:text-xl mb-0.5 sm:mb-2">Responder Perguntas</h2>
+                  <p className="text-muted-foreground text-xs sm:text-sm">Teste seus conhecimentos sobre morfologia</p>
+                </div>
               </div>
-              <h2 className="text-xl mb-2">Responder Perguntas</h2>
-              <p className="text-muted-foreground text-sm">Teste seus conhecimentos sobre morfologia</p>
             </Link>
 
             <Link
               to="/aluno/blocos"
-              className="bg-white rounded-2xl p-6 shadow-lg hover:shadow-2xl hover:-translate-y-1 transition-all group border-2 border-transparent hover:border-yellow-500"
+              className="bg-white rounded-xl sm:rounded-2xl p-4 sm:p-6 shadow-lg hover:shadow-2xl hover:-translate-y-1 transition-all group border-2 border-transparent hover:border-yellow-500"
             >
-              <div className="w-14 h-14 bg-gradient-to-br from-yellow-400 to-yellow-500 rounded-2xl flex items-center justify-center mb-4 group-hover:scale-110 transition-transform">
-                <Puzzle className="w-7 h-7 text-white" />
+              <div className="flex sm:block items-center gap-3">
+                <div className="w-10 h-10 sm:w-14 sm:h-14 bg-gradient-to-br from-yellow-400 to-yellow-500 rounded-xl sm:rounded-2xl flex items-center justify-center sm:mb-4 group-hover:scale-110 transition-transform shrink-0">
+                  <Puzzle className="w-5 h-5 sm:w-7 sm:h-7 text-white" />
+                </div>
+                <div>
+                  <h2 className="text-base sm:text-xl mb-0.5 sm:mb-2">Junção de Blocos</h2>
+                  <p className="text-muted-foreground text-xs sm:text-sm">Monte palavras combinando blocos morfológicos</p>
+                </div>
               </div>
-              <h2 className="text-xl mb-2">Junção de Blocos</h2>
-              <p className="text-muted-foreground text-sm">Monte palavras combinando blocos morfológicos</p>
             </Link>
 
             <Link
               to="/aluno/aprendizagem"
-              className="bg-white rounded-2xl p-6 shadow-lg hover:shadow-2xl hover:-translate-y-1 transition-all group border-2 border-transparent hover:border-red-500 md:col-span-2"
+              className="bg-white rounded-xl sm:rounded-2xl p-4 sm:p-6 shadow-lg hover:shadow-2xl hover:-translate-y-1 transition-all group border-2 border-transparent hover:border-red-500 sm:col-span-2"
             >
-              <div className="flex items-center gap-4">
-                <div className="w-14 h-14 bg-gradient-to-br from-red-500 to-red-600 rounded-2xl flex items-center justify-center group-hover:scale-110 transition-transform">
-                  <Brain className="w-7 h-7 text-white" />
+              <div className="flex items-center gap-3 sm:gap-4">
+                <div className="w-10 h-10 sm:w-14 sm:h-14 bg-gradient-to-br from-red-500 to-red-600 rounded-xl sm:rounded-2xl flex items-center justify-center group-hover:scale-110 transition-transform shrink-0">
+                  <Brain className="w-5 h-5 sm:w-7 sm:h-7 text-white" />
                 </div>
                 <div>
-                  <h2 className="text-xl mb-1">Área de Aprendizagem</h2>
-                  <p className="text-muted-foreground text-sm">Estude conceitos e revise conteúdos</p>
+                  <h2 className="text-base sm:text-xl mb-0.5 sm:mb-1">Área de Aprendizagem</h2>
+                  <p className="text-muted-foreground text-xs sm:text-sm">Estude conceitos e revise conteúdos</p>
                 </div>
               </div>
             </Link>
           </div>
 
-          <div className="bg-white rounded-2xl shadow-lg overflow-hidden">
-            <div className="bg-gradient-to-r from-blue-600 to-blue-700 text-white p-5 flex items-center gap-3">
-              <History className="w-6 h-6" />
+          <div className="bg-white rounded-xl sm:rounded-2xl shadow-lg overflow-hidden">
+            <div className="bg-gradient-to-r from-blue-600 to-blue-700 text-white p-3 sm:p-5 flex items-center gap-3">
+              <History className="w-5 h-5 sm:w-6 sm:h-6" />
               <div>
-                <h3 className="text-lg">Histórico de Questões</h3>
+                <h3 className="text-base sm:text-lg">Histórico de Questões</h3>
                 <div className="text-xs opacity-90">Seu desempenho recente</div>
               </div>
             </div>
-            <div className="p-4 max-h-96 overflow-y-auto">
+            <div className="p-3 sm:p-4 max-h-72 sm:max-h-96 overflow-y-auto">
               {recent.length === 0 ? (
                 <div className="text-center text-muted-foreground py-8 text-sm">
                   Você ainda não respondeu nenhuma questão.


### PR DESCRIPTION
## Resumo
- Ajusta paddings, fontes, ícones e grids para telas pequenas em todas as 7 telas do frontend
- Dashboard do professor usa cards compactos no mobile em vez de tabela
- Modais abrem como bottom sheet no mobile para melhor usabilidade touch

## Telas ajustadas
- Login, Cadastro, Esqueci Senha
- Dashboard do Aluno
- Dashboard do Professor
- Tela de Perguntas
- Área de Aprendizagem

## Test plan
- [x] Testar cada tela em viewport mobile (375px)
- [x] Testar em viewport tablet (768px)
- [x] Verificar que nada quebrou no desktop
- [ ] Validar drag-and-drop dos blocos no mobile