### PR TITLE
feat: ajustes de funcionalidades (cadastro, sufixos, painel professor, reset de senha, area de aprendizado)

### DIFF
--- a/backend/core/serializers.py
+++ b/backend/core/serializers.py
@@ -5,7 +5,7 @@ from core.models import Usuario, Morfema
 class UsuarioSerializer(serializers.ModelSerializer):
     class Meta:
         model = Usuario
-        fields = ["id", "email", "username", "tipo"]
+        fields = ["id", "email", "username", "first_name", "tipo"]
 
 
 class MorfemaSerializer(serializers.ModelSerializer):
@@ -26,15 +26,20 @@ class ValidarPalavraSerializer(serializers.Serializer):
 
 class RegistroSerializer(serializers.ModelSerializer):
     password = serializers.CharField(write_only=True, min_length=6)
+    # O frontend envia o nome completo digitado pelo usuário em "first_name".
+    # Tornamos obrigatório para garantir que o nome real seja sempre persistido
+    # (caso contrário os dashboards exibiriam o email no lugar do nome).
+    first_name = serializers.CharField(required=True, allow_blank=False)
 
     class Meta:
         model = Usuario
-        fields = ["id", "email", "username", "password", "tipo"]
+        fields = ["id", "email", "username", "first_name", "password", "tipo"]
 
     def create(self, validated_data):
         usuario = Usuario(
             email=validated_data["email"],
             username=validated_data["username"],
+            first_name=validated_data["first_name"],
             tipo=validated_data.get("tipo", Usuario.ALUNO),
         )
         usuario.set_password(validated_data["password"])

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -5,6 +5,7 @@ from core.views import (
     MorfemaListView,
     ValidarPalavraView,
     ForgotPasswordView,
+    RelatorioProfessorView,
 )
 
 urlpatterns = [
@@ -13,5 +14,6 @@ urlpatterns = [
     path("auth/forgot-password/", ForgotPasswordView.as_view(), name="forgot-password"),
     path("morfemas/", MorfemaListView.as_view(), name="morfemas"),
     path("validar-palavra/", ValidarPalavraView.as_view(), name="validar-palavra"),
+    path("professor/relatorio/", RelatorioProfessorView.as_view(), name="relatorio-professor"),
 ]
 

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -5,6 +5,7 @@ from core.views import (
     MorfemaListView,
     ValidarPalavraView,
     ForgotPasswordView,
+    ResetPasswordConfirmView,
     RelatorioProfessorView,
 )
 
@@ -12,6 +13,7 @@ urlpatterns = [
     path("auth/me/", MeView.as_view(), name="me"),
     path("auth/registro/", RegistroView.as_view(), name="registro"),
     path("auth/forgot-password/", ForgotPasswordView.as_view(), name="forgot-password"),
+    path("auth/reset-password/", ResetPasswordConfirmView.as_view(), name="reset-password"),
     path("morfemas/", MorfemaListView.as_view(), name="morfemas"),
     path("validar-palavra/", ValidarPalavraView.as_view(), name="validar-palavra"),
     path("professor/relatorio/", RelatorioProfessorView.as_view(), name="relatorio-professor"),

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -4,13 +4,15 @@ from rest_framework.permissions import IsAuthenticated, AllowAny
 from rest_framework.generics import ListAPIView, CreateAPIView
 from rest_framework import status
 
+from urllib.parse import urlsplit
+
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.tokens import PasswordResetTokenGenerator
 from django.core.mail import send_mail
 from django.db.models import Count
 from django.utils.encoding import force_bytes
-from django.utils.http import urlsafe_base64_encode
+from django.utils.http import urlsafe_base64_encode, urlsafe_base64_decode
 
 from core.models import Morfema, PalavraValida, Tentativa, Usuario
 from core.serializers import (
@@ -164,9 +166,14 @@ class ForgotPasswordView(APIView):
                 token = token_generator.make_token(user)
                 uid = urlsafe_base64_encode(force_bytes(user.pk))
 
-                # Link simples (não implementamos a página de reset ainda).
-                # O importante aqui é "mandar o email".
-                reset_url = f"{getattr(settings, 'FRONTEND_RESET_URL', 'http://localhost:5173/reset-senha')}?uid={uid}&token={token}"
+                # Monta o link como hash-route (/#/reset-senha?...). O hash nunca
+                # é enviado ao servidor, então a hospedagem estática (SPA) sempre
+                # serve a raiz e o frontend lê o token no boot — sem necessidade de
+                # rewrite no servidor.
+                base = getattr(settings, "FRONTEND_RESET_URL", "http://localhost:5173/reset-senha")
+                parts = urlsplit(base)
+                caminho = parts.path or "/reset-senha"
+                reset_url = f"{parts.scheme}://{parts.netloc}/#{caminho}?uid={uid}&token={token}"
 
                 subject = "Recuperação de senha"
                 message = (
@@ -185,4 +192,46 @@ class ForgotPasswordView(APIView):
                 )
 
         return Response({"ok": ok, "detail": "Se o email existir, você receberá instruções."}, status=status.HTTP_200_OK)
+
+
+class ResetPasswordConfirmView(APIView):
+    """Confirma a redefinição de senha a partir do link enviado por email.
+
+    Recebe uid + token (gerados na solicitação) e a nova senha. O token do
+    Django é temporário e deixa de ser válido após a troca de senha, atendendo
+    ao requisito de validade limitada e uso único (CA-US03-02).
+    """
+
+    permission_classes = [AllowAny]
+
+    def post(self, request):
+        uid = request.data.get("uid") or ""
+        token = request.data.get("token") or ""
+        password = request.data.get("password") or ""
+
+        User = get_user_model()
+        try:
+            user_pk = urlsafe_base64_decode(uid).decode()
+            user = User.objects.get(pk=user_pk)
+        except (ValueError, TypeError, OverflowError, User.DoesNotExist):
+            user = None
+
+        if user is None or not PasswordResetTokenGenerator().check_token(user, token):
+            return Response(
+                {"detail": "Link inválido ou expirado. Solicite uma nova redefinição."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        if len(password) < 6:
+            return Response(
+                {"detail": "A senha precisa ter pelo menos 6 caracteres."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        user.set_password(password)
+        user.save()
+        return Response(
+            {"detail": "Senha redefinida com sucesso."},
+            status=status.HTTP_200_OK,
+        )
 

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -8,10 +8,11 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.tokens import PasswordResetTokenGenerator
 from django.core.mail import send_mail
+from django.db.models import Count
 from django.utils.encoding import force_bytes
 from django.utils.http import urlsafe_base64_encode
 
-from core.models import Morfema, PalavraValida, Tentativa
+from core.models import Morfema, PalavraValida, Tentativa, Usuario
 from core.serializers import (
     UsuarioSerializer,
     MorfemaSerializer,
@@ -37,6 +38,11 @@ class MorfemaListView(ListAPIView):
     queryset = Morfema.objects.all().order_by("tipo", "texto")
     serializer_class = MorfemaSerializer
     permission_classes = [IsAuthenticated]
+    # A paleta de blocos precisa SEMPRE do catálogo completo de morfemas.
+    # Sem isto, a paginação global do DRF (PAGE_SIZE=10) corta a lista; como os
+    # sufixos ficam por último na ordenação (prefixo < radical < sufixo), eles
+    # desaparecem assim que o catálogo passa de 10 itens.
+    pagination_class = None
 
 
 class ValidarPalavraView(APIView):
@@ -68,6 +74,71 @@ class ValidarPalavraView(APIView):
             "palavra": palavra,
             "processo_morfologico": processo,
         })
+
+
+class RelatorioProfessorView(APIView):
+    """Relatório consolidado de desempenho para o professor (US24/US25).
+
+    Agrega dados reais das Tentativas registradas. Visão geral (todos os
+    alunos), pois o domínio ainda não modela turmas.
+    """
+
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        # RN02: apenas professores podem acessar relatórios consolidados.
+        if getattr(request.user, "tipo", None) != Usuario.PROFESSOR:
+            return Response(
+                {"detail": "Apenas professores podem acessar o relatório."},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
+        tentativas = Tentativa.objects.all()
+        total = tentativas.count()
+        acertos = tentativas.filter(acertou=True).count()
+        erros = total - acertos
+        taxa_acerto = round((acertos / total) * 100) if total else 0
+
+        # US25 — palavras inválidas mais submetidas, em ranking decrescente.
+        palavras_mais_erradas = list(
+            tentativas.filter(acertou=False)
+            .values("palavra")
+            .annotate(ocorrencias=Count("id"))
+            .order_by("-ocorrencias", "palavra")[:10]
+        )
+
+        # US24 — desempenho individual de cada aluno.
+        alunos = Usuario.objects.filter(tipo=Usuario.ALUNO).order_by(
+            "first_name", "username"
+        )
+        por_aluno = []
+        for aluno in alunos:
+            do_aluno = tentativas.filter(usuario=aluno)
+            a_total = do_aluno.count()
+            a_acertos = do_aluno.filter(acertou=True).count()
+            a_pct = round((a_acertos / a_total) * 100) if a_total else 0
+            por_aluno.append(
+                {
+                    "id": aluno.id,
+                    "nome": aluno.first_name or aluno.username,
+                    "email": aluno.email,
+                    "respondidas": a_total,
+                    "acertos": a_acertos,
+                    "aproveitamento": a_pct,
+                }
+            )
+
+        return Response(
+            {
+                "total_alunos": alunos.count(),
+                "total_tentativas": total,
+                "acertos": acertos,
+                "erros": erros,
+                "taxa_acerto": taxa_acerto,
+                "palavras_mais_erradas": palavras_mais_erradas,
+                "alunos": por_aluno,
+            }
+        )
 
 
 class ForgotPasswordView(APIView):

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -4,6 +4,7 @@ import { AppStateProvider, useAppState } from './state/AppState';
 import { Login } from './components/Login';
 import { Register } from './components/Register';
 import { ForgotPassword } from './components/ForgotPassword';
+import { ResetPassword } from './components/ResetPassword';
 import { StudentDashboard } from './components/StudentDashboard';
 import { QuestionsScreen } from './components/QuestionsScreen';
 import { BlockJoining } from './components/BlockJoining';
@@ -21,15 +22,29 @@ function PrivateRoute({ children }: { children: ReactNode }) {
   return <>{children}</>;
 }
 
+// Como usamos MemoryRouter (não lê a URL do navegador), o link de redefinição
+// enviado por email vem como hash-route (ex.: "/#/reset-senha?uid=..&token=..").
+// Aqui lemos esse hash no boot para que o app já abra na tela de reset.
+function getInitialEntries(): string[] {
+  if (typeof window !== 'undefined') {
+    const hash = window.location.hash; // "#/reset-senha?uid=..&token=.."
+    if (hash.startsWith('#/reset-senha')) {
+      return [hash.slice(1)];
+    }
+  }
+  return ['/login'];
+}
+
 export default function App() {
   return (
-    <MemoryRouter initialEntries={['/login']}>
+    <MemoryRouter initialEntries={getInitialEntries()}>
       <AppStateProvider>
         <Routes>
           <Route path="/" element={<Navigate to="/login" replace />} />
           <Route path="/login" element={<Login />} />
           <Route path="/cadastro" element={<Register />} />
           <Route path="/esqueci-senha" element={<ForgotPassword />} />
+          <Route path="/reset-senha" element={<ResetPassword />} />
 
           {/* Rotas do aluno (protegidas) */}
           <Route

--- a/frontend/src/app/components/LearningScreen.tsx
+++ b/frontend/src/app/components/LearningScreen.tsx
@@ -2,7 +2,18 @@ import { useState } from 'react';
 import { Link } from 'react-router';
 import { ArrowLeft, BookOpen, CheckCircle, PlayCircle } from 'lucide-react';
 
-const modules = [
+type Lesson = { titulo: string; conteudo: string };
+type Module = {
+  id: number;
+  title: string;
+  description: string;
+  duration: string;
+  completed: boolean;
+  color: string;
+  lessons: Lesson[];
+};
+
+const modules: Module[] = [
   {
     id: 1,
     title: 'Introdução à Morfologia',
@@ -10,7 +21,23 @@ const modules = [
     duration: '15 min',
     completed: true,
     color: 'bg-blue-600',
-    lessons: ['O que é morfologia?', 'Estrutura das palavras', 'Tipos de morfemas'],
+    lessons: [
+      {
+        titulo: 'O que é morfologia?',
+        conteudo:
+          'A morfologia é a parte da gramática que estuda a estrutura e a formação das palavras. Ela analisa as menores unidades que carregam significado, chamadas morfemas, e a maneira como elas se combinam para formar palavras.',
+      },
+      {
+        titulo: 'Estrutura das palavras',
+        conteudo:
+          'Uma palavra pode ser dividida em partes menores. Em "infeliz", por exemplo, temos o prefixo "in-" (que indica negação) e o radical "feliz". Reconhecer essas partes ajuda a entender o significado e a escrita das palavras.',
+      },
+      {
+        titulo: 'Tipos de morfemas',
+        conteudo:
+          'Os principais morfemas são: o radical (parte central que carrega o significado), o prefixo (vem antes do radical) e o sufixo (vem depois do radical). Existem ainda as desinências, que indicam gênero, número e flexão dos verbos.',
+      },
+    ],
   },
   {
     id: 2,
@@ -19,7 +46,23 @@ const modules = [
     duration: '20 min',
     completed: true,
     color: 'bg-red-500',
-    lessons: ['Definição de prefixo', 'Prefixos de negação', 'Prefixos de origem latina e grega'],
+    lessons: [
+      {
+        titulo: 'Definição de prefixo',
+        conteudo:
+          'Prefixo é o morfema que se coloca antes do radical para formar uma nova palavra, alterando seu significado. Exemplo: "des-" + "fazer" = "desfazer".',
+      },
+      {
+        titulo: 'Prefixos de negação',
+        conteudo:
+          'Alguns prefixos indicam negação ou oposição, como "in-" (infeliz), "des-" (desleal) e "a-" (amoral). Eles invertem ou negam o sentido do radical.',
+      },
+      {
+        titulo: 'Prefixos de origem latina e grega',
+        conteudo:
+          'Muitos prefixos vêm do latim e do grego: "bi-" (dois), "tri-" (três), "re-" (de novo, como em refazer) e "pré-" (antes). Conhecê-los ajuda a deduzir o significado de palavras novas.',
+      },
+    ],
   },
   {
     id: 3,
@@ -28,7 +71,23 @@ const modules = [
     duration: '25 min',
     completed: false,
     color: 'bg-blue-600',
-    lessons: ['O que é radical', 'Família de palavras', 'Radicais cultos'],
+    lessons: [
+      {
+        titulo: 'O que é radical',
+        conteudo:
+          'Radical é a parte da palavra que carrega o significado principal e é comum a toda uma família de palavras. Em "pedra", "pedreiro" e "pedregulho", o radical é "pedr-".',
+      },
+      {
+        titulo: 'Família de palavras',
+        conteudo:
+          'Família de palavras é o conjunto de palavras formadas a partir do mesmo radical. Do radical "flor-", por exemplo, temos florista, floreira, florescer e floricultura.',
+      },
+      {
+        titulo: 'Radicais cultos',
+        conteudo:
+          'Radicais cultos vêm do grego e do latim e formam muitas palavras técnicas: "bio-" (vida), "geo-" (terra) e "tele-" (distância), como em biologia, geografia e telefone.',
+      },
+    ],
   },
   {
     id: 4,
@@ -37,7 +96,23 @@ const modules = [
     duration: '20 min',
     completed: false,
     color: 'bg-yellow-500',
-    lessons: ['Sufixos nominais', 'Sufixos verbais', 'Sufixos diminutivos e aumentativos'],
+    lessons: [
+      {
+        titulo: 'Sufixos nominais',
+        conteudo:
+          'Sufixos nominais formam substantivos e adjetivos a partir de outras palavras. Exemplos: "-eiro" (pedreiro), "-dade" (felicidade) e "-oso" (amoroso).',
+      },
+      {
+        titulo: 'Sufixos verbais',
+        conteudo:
+          'Sufixos verbais formam verbos. Exemplos: "-izar" (realizar), "-ear" (passear) e "-ecer" (anoitecer).',
+      },
+      {
+        titulo: 'Sufixos diminutivos e aumentativos',
+        conteudo:
+          'O sufixo "-inho/-zinho" forma o diminutivo (amorzinho, casinha) e pode indicar afeto. Já o sufixo "-ão/-zão" forma o aumentativo (casarão, livrão).',
+      },
+    ],
   },
   {
     id: 5,
@@ -46,12 +121,30 @@ const modules = [
     duration: '30 min',
     completed: false,
     color: 'bg-red-500',
-    lessons: ['Derivação prefixal', 'Derivação sufixal', 'Composição'],
+    lessons: [
+      {
+        titulo: 'Derivação prefixal',
+        conteudo:
+          'Na derivação prefixal, uma nova palavra é formada acrescentando um prefixo ao radical. Exemplo: "in-" + "feliz" = "infeliz".',
+      },
+      {
+        titulo: 'Derivação sufixal',
+        conteudo:
+          'Na derivação sufixal, a nova palavra é formada acrescentando um sufixo ao radical. Exemplo: "feliz" + "-mente" = "felizmente".',
+      },
+      {
+        titulo: 'Composição',
+        conteudo:
+          'Na composição, duas ou mais palavras se unem para formar uma nova. Pode ser por justaposição (guarda-chuva) ou por aglutinação (planalto = plano + alto).',
+      },
+    ],
   },
 ];
 
 export function LearningScreen() {
   const [expanded, setExpanded] = useState<number | null>(1);
+  // Aula aberta dentro de um módulo, identificada por "moduloId-indice".
+  const [openLesson, setOpenLesson] = useState<string | null>(null);
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-blue-50 via-yellow-50 to-red-50 p-3 sm:p-4">
@@ -109,18 +202,29 @@ export function LearningScreen() {
               {expanded === mod.id && (
                 <div className="border-t border-border p-3 sm:p-6 bg-gray-50">
                   <h4 className="text-sm sm:text-base mb-2 sm:mb-3">Aulas deste módulo:</h4>
-                  <div className="space-y-2 mb-3 sm:mb-4">
-                    {mod.lessons.map((lesson, idx) => (
-                      <div key={idx} className="flex items-center gap-2 sm:gap-3 p-2 sm:p-3 bg-white rounded-lg">
-                        <PlayCircle className="w-4 h-4 sm:w-5 sm:h-5 text-primary flex-shrink-0" />
-                        <span className="flex-1 text-sm sm:text-base">{lesson}</span>
-                        <span className="text-xs sm:text-sm text-muted-foreground">~5 min</span>
-                      </div>
-                    ))}
+                  <div className="space-y-2">
+                    {mod.lessons.map((lesson, idx) => {
+                      const key = `${mod.id}-${idx}`;
+                      const isOpen = openLesson === key;
+                      return (
+                        <div key={idx} className="bg-white rounded-lg overflow-hidden">
+                          <button
+                            onClick={() => setOpenLesson(isOpen ? null : key)}
+                            className="w-full flex items-center gap-2 sm:gap-3 p-2 sm:p-3 text-left hover:bg-gray-50 transition-colors"
+                          >
+                            <PlayCircle className="w-4 h-4 sm:w-5 sm:h-5 text-primary flex-shrink-0" />
+                            <span className="flex-1 text-sm sm:text-base">{lesson.titulo}</span>
+                            <span className="text-xs sm:text-sm text-primary">{isOpen ? 'Fechar' : 'Ler'}</span>
+                          </button>
+                          {isOpen && (
+                            <p className="px-3 sm:px-4 pb-3 sm:pb-4 text-sm sm:text-base text-muted-foreground leading-relaxed">
+                              {lesson.conteudo}
+                            </p>
+                          )}
+                        </div>
+                      );
+                    })}
                   </div>
-                  <button className={`px-4 sm:px-6 py-2 sm:py-3 ${mod.color} text-white rounded-lg hover:opacity-90 transition-opacity text-sm sm:text-base`}>
-                    {mod.completed ? 'Revisar Módulo' : 'Iniciar Módulo'}
-                  </button>
                 </div>
               )}
             </div>

--- a/frontend/src/app/components/ProfessorDashboard.tsx
+++ b/frontend/src/app/components/ProfessorDashboard.tsx
@@ -1,88 +1,72 @@
-import { useState, useMemo } from 'react';
+import { useEffect, useState } from 'react';
 import { Link } from 'react-router';
-import { Users, TrendingUp, Award, AlertCircle, LogOut, User, Plus, GraduationCap, X } from 'lucide-react';
+import { Users, TrendingUp, Award, AlertCircle, LogOut, User, Loader2 } from 'lucide-react';
 import {
-  BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer,
-  LineChart, Line, Legend, Cell,
+  BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Cell,
 } from 'recharts';
 import { Logo } from './Logo';
 import { useAppState } from '../state/AppState';
-import type { Topic } from '../state/AppState';
+import { api } from '../../lib/api';
 
-const TOPICS: Topic[] = ['Prefixos', 'Radicais', 'Sufixos', 'Composição', 'Derivação'];
+// Formato cru vindo do backend (GET /api/professor/relatorio/).
+type PalavraErrada = { palavra: string; ocorrencias: number };
+type AlunoRelatorio = {
+  id: number;
+  nome: string;
+  email: string;
+  respondidas: number;
+  acertos: number;
+  aproveitamento: number;
+};
+type Relatorio = {
+  total_alunos: number;
+  total_tentativas: number;
+  acertos: number;
+  erros: number;
+  taxa_acerto: number;
+  palavras_mais_erradas: PalavraErrada[];
+  alunos: AlunoRelatorio[];
+};
+
+// Classifica o status do aluno a partir do aproveitamento.
+function statusDoAluno(respondidas: number, pct: number) {
+  if (respondidas === 0) return { status: 'Sem dados', color: 'bg-gray-200 text-gray-700', barColor: 'bg-gray-400' };
+  if (pct >= 80) return { status: 'Excelente', color: 'bg-blue-100 text-blue-700', barColor: 'bg-blue-600' };
+  if (pct >= 65) return { status: 'Bom', color: 'bg-yellow-100 text-yellow-700', barColor: 'bg-yellow-500' };
+  if (pct >= 50) return { status: 'Regular', color: 'bg-orange-100 text-orange-700', barColor: 'bg-orange-500' };
+  return { status: 'Precisa Ajuda', color: 'bg-red-100 text-red-700', barColor: 'bg-red-500' };
+}
 
 export function ProfessorDashboard() {
-  const { turmas, students, history, professorId, addTurma, addStudent, usuario } = useAppState();
-  const myTurmas = turmas.filter((t) => t.professorId === professorId);
-  const [selectedClassId, setSelectedClassId] = useState<string>(myTurmas[0]?.id ?? '');
-  const [showTurmaModal, setShowTurmaModal] = useState(false);
-  const [showAlunoModal, setShowAlunoModal] = useState(false);
+  const { usuario } = useAppState();
+  const [relatorio, setRelatorio] = useState<Relatorio | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
-  const [turmaName, setTurmaName] = useState('');
-  const [turmaSerie, setTurmaSerie] = useState('');
-  const [alunoName, setAlunoName] = useState('');
-  const [alunoEmail, setAlunoEmail] = useState('');
-  const [alunoClassId, setAlunoClassId] = useState(selectedClassId);
+  useEffect(() => {
+    let active = true;
+    api
+      .get<Relatorio>('/professor/relatorio/')
+      .then(({ data }) => {
+        if (active) setRelatorio(data);
+      })
+      .catch((err) => {
+        console.error('Falha ao carregar relatório:', err);
+        if (active) setError('Não foi possível carregar o relatório. Tente novamente.');
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
 
-  const classStudents = useMemo(
-    () => students.filter((s) => s.classId === selectedClassId),
-    [students, selectedClassId]
-  );
-  const classStudentIds = classStudents.map((s) => s.id);
-  const classHistory = useMemo(
-    () => history.filter((h) => classStudentIds.includes(h.studentId)),
-    [history, classStudentIds]
-  );
-
-  // Métricas
-  const totalStudents = classStudents.length;
-  const totalAnswers = classHistory.length;
-  const correctAnswers = classHistory.filter((h) => h.correct).length;
-  const avgPct = totalAnswers ? Math.round((correctAnswers / totalAnswers) * 100) : 0;
-  const concluidos = classStudents.filter((s) => {
-    const sh = classHistory.filter((h) => h.studentId === s.id);
-    return sh.length >= 3 && sh.filter((h) => h.correct).length / sh.length >= 0.8;
-  }).length;
-  const precisamAjuda = classStudents.filter((s) => {
-    const sh = classHistory.filter((h) => h.studentId === s.id);
-    return sh.length > 0 && sh.filter((h) => h.correct).length / sh.length < 0.5;
-  }).length;
-
-  // Gráfico de erros (ordenado decrescente)
-  const errorsByTopic = TOPICS.map((topic) => {
-    const items = classHistory.filter((h) => h.topic === topic);
-    const erros = items.filter((h) => !h.correct).length;
-    const acertos = items.filter((h) => h.correct).length;
-    return { topico: topic, erros, acertos, total: items.length };
-  })
-    .filter((t) => t.total > 0)
-    .sort((a, b) => b.erros - a.erros);
-
-  const maxErros = Math.max(...errorsByTopic.map((e) => e.erros), 1);
-
-  // Evolução semanal (mock baseado em datas)
-  const evolutionData = (() => {
-    const sorted = [...classHistory].sort((a, b) => a.date.localeCompare(b.date));
-    const buckets: Record<string, { acertos: number; erros: number }> = {};
-    sorted.forEach((h) => {
-      buckets[h.date] = buckets[h.date] ?? { acertos: 0, erros: 0 };
-      if (h.correct) buckets[h.date].acertos++;
-      else buckets[h.date].erros++;
-    });
-    return Object.entries(buckets).map(([date, v]) => ({ date: date.slice(5), ...v }));
-  })();
-
-  const handleCreateTurma = () => {
-    if (!turmaName.trim()) return;
-    addTurma(turmaName, turmaSerie || 'Não definido');
-    setTurmaName(''); setTurmaSerie(''); setShowTurmaModal(false);
-  };
-
-  const handleCreateAluno = () => {
-    if (!alunoName.trim() || !alunoClassId) return;
-    addStudent(alunoName, alunoEmail, alunoClassId);
-    setAlunoName(''); setAlunoEmail(''); setShowAlunoModal(false);
-  };
+  const alunos = relatorio?.alunos ?? [];
+  const palavrasErradas = relatorio?.palavras_mais_erradas ?? [];
+  const altoDesempenho = alunos.filter((a) => a.respondidas >= 3 && a.aproveitamento >= 80).length;
+  const precisamAjuda = alunos.filter((a) => a.respondidas > 0 && a.aproveitamento < 50).length;
+  const maxOcorrencias = Math.max(...palavrasErradas.map((p) => p.ocorrencias), 1);
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-blue-50 via-yellow-50 to-red-50">
@@ -98,7 +82,7 @@ export function ProfessorDashboard() {
           <div className="flex items-center gap-2 sm:gap-4 shrink-0">
             <div className="text-right hidden sm:block">
               <div className="text-sm text-muted-foreground">Prof.</div>
-              <div>{usuario?.username}</div>
+              <div>{usuario?.first_name?.trim() || usuario?.username}</div>
             </div>
             <div className="w-8 h-8 sm:w-10 sm:h-10 bg-gradient-to-br from-blue-600 to-blue-700 rounded-full flex items-center justify-center text-white shadow">
               <User className="w-4 h-4 sm:w-5 sm:h-5" />
@@ -111,56 +95,26 @@ export function ProfessorDashboard() {
       </header>
 
       <main className="max-w-7xl mx-auto px-3 sm:px-4 py-4 sm:py-8">
-        {/* Seletor de Turma + Ações */}
-        <div className="bg-white rounded-xl sm:rounded-2xl shadow-lg p-3 sm:p-5 mb-4 sm:mb-6 flex flex-col gap-3 sm:gap-4 md:flex-row md:items-center md:justify-between">
-          <div className="flex items-center gap-2 sm:gap-3 flex-wrap">
-            <GraduationCap className="w-5 h-5 sm:w-6 sm:h-6 text-blue-600" />
-            <span className="text-sm sm:text-base text-muted-foreground">Turma selecionada:</span>
-            {myTurmas.length === 0 ? (
-              <span className="text-muted-foreground italic">Nenhuma turma criada</span>
-            ) : (
-              <div className="flex flex-wrap gap-2">
-                {myTurmas.map((t) => (
-                  <button
-                    key={t.id}
-                    onClick={() => setSelectedClassId(t.id)}
-                    className={`px-4 py-2 rounded-xl transition-all ${
-                      selectedClassId === t.id
-                        ? 'bg-gradient-to-r from-blue-600 to-blue-700 text-white shadow-md'
-                        : 'bg-gray-100 hover:bg-gray-200'
-                    }`}
-                  >
-                    {t.name}
-                  </button>
-                ))}
-              </div>
-            )}
+        {loading && (
+          <div className="flex items-center justify-center gap-2 py-20 text-muted-foreground">
+            <Loader2 className="w-6 h-6 animate-spin" /> Carregando relatório...
           </div>
-          <div className="flex gap-2">
-            <button
-              onClick={() => setShowTurmaModal(true)}
-              className="px-3 sm:px-4 py-2 bg-yellow-400 text-white rounded-xl hover:bg-yellow-500 transition-colors flex items-center gap-1.5 sm:gap-2 shadow-md text-sm sm:text-base"
-            >
-              <Plus className="w-4 h-4" /> <span className="hidden xs:inline">Nova</span> Turma
-            </button>
-            <button
-              onClick={() => { setAlunoClassId(selectedClassId); setShowAlunoModal(true); }}
-              disabled={myTurmas.length === 0}
-              className="px-3 sm:px-4 py-2 bg-blue-600 text-white rounded-xl hover:bg-blue-700 transition-colors flex items-center gap-1.5 sm:gap-2 shadow-md disabled:opacity-50 text-sm sm:text-base"
-            >
-              <Plus className="w-4 h-4" /> <span className="hidden sm:inline">Cadastrar</span> Aluno
-            </button>
-          </div>
-        </div>
+        )}
 
-        {selectedClassId ? (
+        {!loading && error && (
+          <div className="p-4 bg-red-50 border-l-4 border-red-500 rounded-xl text-sm text-red-700">
+            {error}
+          </div>
+        )}
+
+        {!loading && !error && relatorio && (
           <>
             {/* Stats */}
             <div className="grid grid-cols-2 lg:grid-cols-4 gap-2 sm:gap-4 mb-4 sm:mb-8">
               {[
-                { icon: Users, label: 'Alunos na Turma', value: String(totalStudents), bg: 'bg-blue-100', text: 'text-blue-600', border: 'border-blue-600' },
-                { icon: TrendingUp, label: 'Média da Turma', value: `${avgPct}%`, bg: 'bg-yellow-100', text: 'text-yellow-600', border: 'border-yellow-400' },
-                { icon: Award, label: 'Alto Desempenho', value: String(concluidos), bg: 'bg-green-100', text: 'text-green-600', border: 'border-green-500' },
+                { icon: Users, label: 'Alunos', value: String(relatorio.total_alunos), bg: 'bg-blue-100', text: 'text-blue-600', border: 'border-blue-600' },
+                { icon: TrendingUp, label: 'Taxa de Acerto', value: `${relatorio.taxa_acerto}%`, bg: 'bg-yellow-100', text: 'text-yellow-600', border: 'border-yellow-400' },
+                { icon: Award, label: 'Alto Desempenho', value: String(altoDesempenho), bg: 'bg-green-100', text: 'text-green-600', border: 'border-green-500' },
                 { icon: AlertCircle, label: 'Precisam Ajuda', value: String(precisamAjuda), bg: 'bg-red-100', text: 'text-red-600', border: 'border-red-500' },
               ].map((stat, i) => (
                 <div key={i} className={`bg-white rounded-xl sm:rounded-2xl p-3 sm:p-5 shadow-lg border-l-4 ${stat.border} hover:shadow-xl transition-shadow`}>
@@ -177,128 +131,98 @@ export function ProfessorDashboard() {
               ))}
             </div>
 
-            {/* Gráficos */}
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-3 sm:gap-6 mb-4 sm:mb-8">
-              {/* Gráfico de erros — destaque para o que mais erram */}
+            {/* Gráfico + Resumo */}
+            <div className="grid grid-cols-1 lg:grid-cols-3 gap-3 sm:gap-6 mb-4 sm:mb-8">
+              {/* Palavras mais erradas (US25) */}
               <div className="bg-white rounded-xl sm:rounded-2xl p-3 sm:p-6 shadow-lg lg:col-span-2">
                 <div className="flex flex-col sm:flex-row sm:items-center justify-between mb-3 sm:mb-4 gap-2">
                   <div>
-                    <h3 className="text-base sm:text-xl">Onde os alunos mais erram</h3>
-                    <p className="text-xs sm:text-sm text-muted-foreground">Tópicos ordenados pelo número de erros</p>
+                    <h3 className="text-base sm:text-xl">Palavras que os alunos mais erram</h3>
+                    <p className="text-xs sm:text-sm text-muted-foreground">Combinações inválidas mais submetidas</p>
                   </div>
                   <div className="px-2 sm:px-3 py-1 bg-red-100 text-red-700 rounded-full text-xs sm:text-sm self-start sm:self-auto">
                     Foco em revisão
                   </div>
                 </div>
-                {errorsByTopic.length === 0 ? (
-                  <div className="text-center text-muted-foreground py-12">
-                    Esta turma ainda não respondeu nenhuma questão.
+                {palavrasErradas.length === 0 ? (
+                  <div className="text-center text-muted-foreground py-12 text-sm">
+                    Os alunos ainda não submeteram combinações inválidas.
                   </div>
                 ) : (
-                  <ResponsiveContainer width="100%" height={250}>
-                    <BarChart data={errorsByTopic} layout="vertical" margin={{ left: 0, right: 10 }}>
+                  <ResponsiveContainer width="100%" height={260}>
+                    <BarChart data={palavrasErradas} layout="vertical" margin={{ left: 0, right: 10 }}>
                       <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" />
-                      <XAxis type="number" />
-                      <YAxis type="category" dataKey="topico" width={100} />
+                      <XAxis type="number" allowDecimals={false} />
+                      <YAxis type="category" dataKey="palavra" width={100} />
                       <Tooltip />
-                      <Legend />
-                      <Bar dataKey="erros" name="Erros" radius={[0, 8, 8, 0]}>
-                        {errorsByTopic.map((entry, idx) => {
-                          const intensity = entry.erros / maxErros;
+                      <Bar dataKey="ocorrencias" name="Ocorrências" radius={[0, 8, 8, 0]}>
+                        {palavrasErradas.map((entry, idx) => {
+                          const intensity = entry.ocorrencias / maxOcorrencias;
                           const color = intensity > 0.7 ? '#ef4444' : intensity > 0.4 ? '#fbbf24' : '#3b82f6';
                           return <Cell key={idx} fill={color} />;
                         })}
                       </Bar>
-                      <Bar dataKey="acertos" name="Acertos" fill="#86efac" radius={[0, 8, 8, 0]} />
                     </BarChart>
                   </ResponsiveContainer>
                 )}
               </div>
 
-              <div className="bg-white rounded-xl sm:rounded-2xl p-3 sm:p-6 shadow-lg">
-                <h3 className="text-base sm:text-xl mb-3 sm:mb-4">Evolução por Data</h3>
-                {evolutionData.length === 0 ? (
-                  <div className="text-center text-muted-foreground py-8 sm:py-12 text-sm">Sem dados ainda</div>
-                ) : (
-                  <ResponsiveContainer width="100%" height={220}>
-                    <LineChart data={evolutionData}>
-                      <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" />
-                      <XAxis dataKey="date" />
-                      <YAxis />
-                      <Tooltip />
-                      <Legend />
-                      <Line type="monotone" dataKey="acertos" stroke="#2563eb" strokeWidth={3} name="Acertos" />
-                      <Line type="monotone" dataKey="erros" stroke="#ef4444" strokeWidth={3} name="Erros" />
-                    </LineChart>
-                  </ResponsiveContainer>
-                )}
-              </div>
-
+              {/* Resumo geral */}
               <div className="bg-gradient-to-br from-blue-600 to-blue-700 text-white rounded-xl sm:rounded-2xl p-4 sm:p-6 shadow-lg">
-                <h3 className="text-base sm:text-xl mb-3 sm:mb-4">Resumo da Turma</h3>
+                <h3 className="text-base sm:text-xl mb-3 sm:mb-4">Resumo Geral</h3>
                 <div className="space-y-4">
                   <div>
-                    <div className="flex justify-between mb-1"><span>Questões respondidas</span><span>{totalAnswers}</span></div>
+                    <div className="flex justify-between mb-1"><span>Tentativas registradas</span><span>{relatorio.total_tentativas}</span></div>
                     <div className="bg-white/20 rounded-full h-2 overflow-hidden">
-                      <div className="bg-yellow-400 h-full" style={{ width: `${Math.min(100, totalAnswers * 5)}%` }} />
+                      <div className="bg-yellow-400 h-full" style={{ width: `${Math.min(100, relatorio.total_tentativas * 5)}%` }} />
                     </div>
                   </div>
                   <div>
-                    <div className="flex justify-between mb-1"><span>Taxa de acerto</span><span>{avgPct}%</span></div>
+                    <div className="flex justify-between mb-1"><span>Taxa de acerto</span><span>{relatorio.taxa_acerto}%</span></div>
                     <div className="bg-white/20 rounded-full h-2 overflow-hidden">
-                      <div className="bg-yellow-400 h-full" style={{ width: `${avgPct}%` }} />
+                      <div className="bg-yellow-400 h-full" style={{ width: `${relatorio.taxa_acerto}%` }} />
                     </div>
                   </div>
                   <div className="pt-2 text-sm opacity-90">
-                    {errorsByTopic[0]
-                      ? `📌 O tópico "${errorsByTopic[0].topico}" é o que mais precisa de atenção.`
-                      : '📌 Aguardando respostas dos alunos.'}
+                    {palavrasErradas[0]
+                      ? `📌 A palavra "${palavrasErradas[0].palavra}" é a que mais gera erros.`
+                      : '📌 Aguardando submissões dos alunos.'}
                   </div>
                 </div>
               </div>
             </div>
 
-            {/* Lista de alunos */}
+            {/* Lista de alunos (US24) */}
             <div className="bg-white rounded-xl sm:rounded-2xl shadow-lg p-3 sm:p-6">
               <h3 className="text-base sm:text-xl mb-3 sm:mb-4">Acompanhamento dos Alunos</h3>
-              {classStudents.length === 0 ? (
+              {alunos.length === 0 ? (
                 <div className="text-center text-muted-foreground py-6 sm:py-8 text-sm">
-                  Nenhum aluno cadastrado nesta turma. Use o botão "Cadastrar Aluno".
+                  Nenhum aluno cadastrado ainda.
                 </div>
               ) : (
                 <>
                   {/* Mobile: cards */}
                   <div className="sm:hidden space-y-3">
-                    {classStudents.map((s) => {
-                      const sh = classHistory.filter((h) => h.studentId === s.id);
-                      const total = sh.length;
-                      const c = sh.filter((h) => h.correct).length;
-                      const pct = total ? Math.round((c / total) * 100) : 0;
-                      let status = 'Sem dados', color = 'bg-gray-200 text-gray-700', barColor = 'bg-gray-400';
-                      if (total > 0) {
-                        if (pct >= 80) { status = 'Excelente'; color = 'bg-blue-100 text-blue-700'; barColor = 'bg-blue-600'; }
-                        else if (pct >= 65) { status = 'Bom'; color = 'bg-yellow-100 text-yellow-700'; barColor = 'bg-yellow-500'; }
-                        else if (pct >= 50) { status = 'Regular'; color = 'bg-orange-100 text-orange-700'; barColor = 'bg-orange-500'; }
-                        else { status = 'Precisa Ajuda'; color = 'bg-red-100 text-red-700'; barColor = 'bg-red-500'; }
-                      }
+                    {alunos.map((a) => {
+                      const { status, color, barColor } = statusDoAluno(a.respondidas, a.aproveitamento);
                       return (
-                        <div key={s.id} className="border border-border rounded-xl p-3">
+                        <div key={a.id} className="border border-border rounded-xl p-3">
                           <div className="flex items-center gap-3 mb-2">
                             <div className={`w-9 h-9 ${barColor} rounded-full flex items-center justify-center text-white text-sm`}>
-                              {s.name.charAt(0)}
+                              {a.nome.charAt(0).toUpperCase()}
                             </div>
                             <div className="min-w-0 flex-1">
-                              <div className="text-sm truncate">{s.name}</div>
-                              <div className="text-xs text-muted-foreground truncate">{s.email}</div>
+                              <div className="text-sm truncate">{a.nome}</div>
+                              <div className="text-xs text-muted-foreground truncate">{a.email}</div>
                             </div>
                             <span className={`text-xs px-2 py-0.5 rounded-full shrink-0 ${color}`}>{status}</span>
                           </div>
                           <div className="flex items-center gap-2 text-xs text-muted-foreground">
-                            <span>{total} resp.</span>
+                            <span>{a.respondidas} resp.</span>
                             <div className="flex-1 bg-gray-200 rounded-full h-1.5 overflow-hidden">
-                              <div className={`${barColor} h-full`} style={{ width: `${pct}%` }} />
+                              <div className={`${barColor} h-full`} style={{ width: `${a.aproveitamento}%` }} />
                             </div>
-                            <span>{pct}%</span>
+                            <span>{a.aproveitamento}%</span>
                           </div>
                         </div>
                       );
@@ -316,38 +240,28 @@ export function ProfessorDashboard() {
                         </tr>
                       </thead>
                       <tbody>
-                        {classStudents.map((s) => {
-                          const sh = classHistory.filter((h) => h.studentId === s.id);
-                          const total = sh.length;
-                          const c = sh.filter((h) => h.correct).length;
-                          const pct = total ? Math.round((c / total) * 100) : 0;
-                          let status = 'Sem dados', color = 'bg-gray-200 text-gray-700', barColor = 'bg-gray-400';
-                          if (total > 0) {
-                            if (pct >= 80) { status = 'Excelente'; color = 'bg-blue-100 text-blue-700'; barColor = 'bg-blue-600'; }
-                            else if (pct >= 65) { status = 'Bom'; color = 'bg-yellow-100 text-yellow-700'; barColor = 'bg-yellow-500'; }
-                            else if (pct >= 50) { status = 'Regular'; color = 'bg-orange-100 text-orange-700'; barColor = 'bg-orange-500'; }
-                            else { status = 'Precisa Ajuda'; color = 'bg-red-100 text-red-700'; barColor = 'bg-red-500'; }
-                          }
+                        {alunos.map((a) => {
+                          const { status, color, barColor } = statusDoAluno(a.respondidas, a.aproveitamento);
                           return (
-                            <tr key={s.id} className="border-b border-border last:border-0">
+                            <tr key={a.id} className="border-b border-border last:border-0">
                               <td className="py-4">
                                 <div className="flex items-center gap-3">
                                   <div className={`w-10 h-10 ${barColor} rounded-full flex items-center justify-center text-white`}>
-                                    {s.name.charAt(0)}
+                                    {a.nome.charAt(0).toUpperCase()}
                                   </div>
                                   <div>
-                                    <div>{s.name}</div>
-                                    <div className="text-xs text-muted-foreground">{s.email}</div>
+                                    <div>{a.nome}</div>
+                                    <div className="text-xs text-muted-foreground">{a.email}</div>
                                   </div>
                                 </div>
                               </td>
-                              <td className="py-4">{total}</td>
+                              <td className="py-4">{a.respondidas}</td>
                               <td className="py-4">
                                 <div className="flex items-center gap-3 min-w-40">
                                   <div className="flex-1 bg-gray-200 rounded-full h-2 overflow-hidden">
-                                    <div className={`${barColor} h-full`} style={{ width: `${pct}%` }} />
+                                    <div className={`${barColor} h-full`} style={{ width: `${a.aproveitamento}%` }} />
                                   </div>
-                                  <span className="text-sm w-10">{pct}%</span>
+                                  <span className="text-sm w-10">{a.aproveitamento}%</span>
                                 </div>
                               </td>
                               <td className="py-4">
@@ -363,115 +277,8 @@ export function ProfessorDashboard() {
               )}
             </div>
           </>
-        ) : (
-          <div className="bg-white rounded-xl sm:rounded-2xl shadow-lg p-8 sm:p-12 text-center">
-            <GraduationCap className="w-12 h-12 sm:w-16 sm:h-16 text-blue-600 mx-auto mb-3 sm:mb-4" />
-            <h3 className="text-lg sm:text-xl mb-2">Crie sua primeira turma</h3>
-            <p className="text-sm sm:text-base text-muted-foreground mb-4 sm:mb-6">
-              Você ainda não tem turmas. Clique em "Nova Turma" para começar.
-            </p>
-            <button
-              onClick={() => setShowTurmaModal(true)}
-              className="px-5 sm:px-6 py-3 bg-blue-600 text-white rounded-xl hover:bg-blue-700 transition-colors inline-flex items-center gap-2 text-sm sm:text-base"
-            >
-              <Plus className="w-5 h-5" /> Criar Turma
-            </button>
-          </div>
         )}
       </main>
-
-      {/* Modal Nova Turma */}
-      {showTurmaModal && (
-        <Modal title="Criar Nova Turma" onClose={() => setShowTurmaModal(false)}>
-          <div className="space-y-4">
-            <div>
-              <label className="block mb-2 text-sm">Nome da Turma</label>
-              <input
-                value={turmaName}
-                onChange={(e) => setTurmaName(e.target.value)}
-                placeholder="Ex: 8º Ano C"
-                className="w-full px-4 py-3 bg-input-background rounded-lg border border-border focus:outline-none focus:ring-2 focus:ring-primary"
-              />
-            </div>
-            <div>
-              <label className="block mb-2 text-sm">Série</label>
-              <input
-                value={turmaSerie}
-                onChange={(e) => setTurmaSerie(e.target.value)}
-                placeholder="Ex: 8º Ano"
-                className="w-full px-4 py-3 bg-input-background rounded-lg border border-border focus:outline-none focus:ring-2 focus:ring-primary"
-              />
-            </div>
-            <button
-              onClick={handleCreateTurma}
-              className="w-full py-3 bg-primary text-white rounded-xl hover:bg-primary/90 transition-colors"
-            >
-              Criar Turma
-            </button>
-          </div>
-        </Modal>
-      )}
-
-      {/* Modal Cadastrar Aluno */}
-      {showAlunoModal && (
-        <Modal title="Cadastrar Aluno" onClose={() => setShowAlunoModal(false)}>
-          <div className="space-y-4">
-            <div>
-              <label className="block mb-2 text-sm">Nome Completo</label>
-              <input
-                value={alunoName}
-                onChange={(e) => setAlunoName(e.target.value)}
-                placeholder="Nome do aluno"
-                className="w-full px-4 py-3 bg-input-background rounded-lg border border-border focus:outline-none focus:ring-2 focus:ring-primary"
-              />
-            </div>
-            <div>
-              <label className="block mb-2 text-sm">Email</label>
-              <input
-                type="email"
-                value={alunoEmail}
-                onChange={(e) => setAlunoEmail(e.target.value)}
-                placeholder="aluno@email.com"
-                className="w-full px-4 py-3 bg-input-background rounded-lg border border-border focus:outline-none focus:ring-2 focus:ring-primary"
-              />
-            </div>
-            <div>
-              <label className="block mb-2 text-sm">Turma</label>
-              <select
-                value={alunoClassId}
-                onChange={(e) => setAlunoClassId(e.target.value)}
-                className="w-full px-4 py-3 bg-input-background rounded-lg border border-border focus:outline-none focus:ring-2 focus:ring-primary"
-              >
-                {myTurmas.map((t) => (
-                  <option key={t.id} value={t.id}>{t.name}</option>
-                ))}
-              </select>
-            </div>
-            <button
-              onClick={handleCreateAluno}
-              className="w-full py-3 bg-primary text-white rounded-xl hover:bg-primary/90 transition-colors"
-            >
-              Cadastrar Aluno
-            </button>
-          </div>
-        </Modal>
-      )}
-    </div>
-  );
-}
-
-function Modal({ title, onClose, children }: { title: string; onClose: () => void; children: React.ReactNode }) {
-  return (
-    <div className="fixed inset-0 bg-black/50 flex items-end sm:items-center justify-center sm:p-4 z-50" onClick={onClose}>
-      <div className="bg-white rounded-t-2xl sm:rounded-2xl shadow-2xl p-5 sm:p-6 max-w-md w-full max-h-[90vh] overflow-y-auto" onClick={(e) => e.stopPropagation()}>
-        <div className="flex items-center justify-between mb-4">
-          <h3 className="text-lg sm:text-xl">{title}</h3>
-          <button onClick={onClose} className="text-muted-foreground hover:text-foreground">
-            <X className="w-5 h-5" />
-          </button>
-        </div>
-        {children}
-      </div>
     </div>
   );
 }

--- a/frontend/src/app/components/ResetPassword.tsx
+++ b/frontend/src/app/components/ResetPassword.tsx
@@ -1,0 +1,157 @@
+import { useState } from 'react';
+import { Link, useNavigate, useSearchParams } from 'react-router';
+import { Lock, Eye, EyeOff, ArrowLeft, CheckCircle, Loader2 } from 'lucide-react';
+import { Logo } from './Logo';
+import { api } from '../../lib/api';
+
+export function ResetPassword() {
+  const [params] = useSearchParams();
+  const uid = params.get('uid') ?? '';
+  const token = params.get('token') ?? '';
+
+  const [password, setPassword] = useState('');
+  const [confirm, setConfirm] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [done, setDone] = useState(false);
+  const navigate = useNavigate();
+
+  // Sem uid/token o link é inválido (acesso direto à rota, por exemplo).
+  const linkInvalido = !uid || !token;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    if (password.length < 6) {
+      setError('A senha precisa ter pelo menos 6 caracteres.');
+      return;
+    }
+    if (password !== confirm) {
+      setError('As senhas não coincidem.');
+      return;
+    }
+    setLoading(true);
+    try {
+      await api.post('/auth/reset-password/', { uid, token, password });
+      setDone(true);
+    } catch (err: unknown) {
+      const detail =
+        typeof err === 'object' && err !== null && 'response' in err
+          ? (err as { response?: { data?: { detail?: string } } }).response?.data?.detail
+          : undefined;
+      setError(detail ?? 'Não foi possível redefinir a senha. Tente novamente.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (done) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-50 via-yellow-50 to-red-50 p-4">
+        <div className="w-full max-w-md">
+          <div className="bg-white rounded-2xl shadow-xl p-5 sm:p-8 text-center">
+            <div className="inline-flex items-center justify-center w-16 h-16 sm:w-20 sm:h-20 bg-green-100 rounded-full mb-4 sm:mb-6">
+              <CheckCircle className="w-8 h-8 sm:w-10 sm:h-10 text-green-600" />
+            </div>
+            <h1 className="text-2xl sm:text-3xl mb-3">Senha redefinida!</h1>
+            <p className="text-sm sm:text-base text-muted-foreground mb-8">
+              Sua senha foi alterada com sucesso. Agora você já pode entrar com a nova senha.
+            </p>
+            <button
+              onClick={() => navigate('/login')}
+              className="w-full py-3 bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition-colors"
+            >
+              Ir para o login
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-50 via-yellow-50 to-red-50 p-4">
+      <div className="w-full max-w-md">
+        <div className="bg-white rounded-2xl shadow-xl p-5 sm:p-8">
+          <div className="text-center mb-6 sm:mb-8">
+            <div className="flex justify-center mb-4 sm:mb-6"><Logo size="cover" /></div>
+            <h1 className="text-2xl sm:text-3xl mb-2">Redefinir Senha</h1>
+            <p className="text-sm sm:text-base text-muted-foreground">
+              Escolha uma nova senha para sua conta.
+            </p>
+          </div>
+
+          {linkInvalido ? (
+            <div className="p-3 bg-red-50 border-l-4 border-red-500 rounded-lg text-sm text-red-700">
+              Link inválido. Solicite uma nova redefinição na tela de login.
+            </div>
+          ) : (
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <div>
+                <label htmlFor="password" className="block mb-2">Nova senha</label>
+                <div className="relative">
+                  <Lock className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-muted-foreground" />
+                  <input
+                    id="password"
+                    type={showPassword ? 'text' : 'password'}
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    placeholder="••••••••"
+                    className="w-full pl-10 pr-12 py-3 bg-input-background rounded-lg border border-border focus:outline-none focus:ring-2 focus:ring-primary"
+                    required
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setShowPassword(!showPassword)}
+                    className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                  >
+                    {showPassword ? <EyeOff className="w-5 h-5" /> : <Eye className="w-5 h-5" />}
+                  </button>
+                </div>
+              </div>
+
+              <div>
+                <label htmlFor="confirm" className="block mb-2">Confirmar nova senha</label>
+                <div className="relative">
+                  <Lock className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-muted-foreground" />
+                  <input
+                    id="confirm"
+                    type={showPassword ? 'text' : 'password'}
+                    value={confirm}
+                    onChange={(e) => setConfirm(e.target.value)}
+                    placeholder="••••••••"
+                    className="w-full pl-10 pr-4 py-3 bg-input-background rounded-lg border border-border focus:outline-none focus:ring-2 focus:ring-primary"
+                    required
+                  />
+                </div>
+              </div>
+
+              {error && (
+                <div className="p-3 bg-red-50 border-l-4 border-red-500 rounded-lg text-sm text-red-700">
+                  {error}
+                </div>
+              )}
+
+              <button
+                type="submit"
+                disabled={loading}
+                className="w-full py-3 bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition-colors disabled:opacity-50 flex items-center justify-center gap-2"
+              >
+                {loading && <Loader2 className="w-5 h-5 animate-spin" />}
+                {loading ? 'Redefinindo...' : 'Redefinir Senha'}
+              </button>
+            </form>
+          )}
+
+          <div className="mt-6 text-center">
+            <Link to="/login" className="inline-flex items-center gap-2 text-sm text-primary hover:underline">
+              <ArrowLeft className="w-4 h-4" />
+              Voltar para login
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/components/StudentDashboard.tsx
+++ b/frontend/src/app/components/StudentDashboard.tsx
@@ -5,8 +5,8 @@ import { useAppState } from '../state/AppState';
 
 export function StudentDashboard() {
   const { history, currentStudentId, usuario } = useAppState();
-  // const student = students.find((s) => s.id === currentStudentId);
-  const studentName = usuario?.username ?? 'Aluno';
+  // Exibe o nome real (first_name); cai para username/email só se vazio.
+  const studentName = usuario?.first_name?.trim() || usuario?.username || 'Aluno';
 
   const myHistory = history.filter((h) => h.studentId === currentStudentId);
   const totalAnswered = myHistory.length;

--- a/frontend/src/app/state/AppState.tsx
+++ b/frontend/src/app/state/AppState.tsx
@@ -15,6 +15,7 @@ export type Usuario = {
   id: number;
   email: string;
   username: string;
+  first_name: string;
   tipo: TipoUsuario;
 };
 


### PR DESCRIPTION
## Resumo

Correções e funcionalidades mapeadas às User Stories do backlog (GitPages):

- **Cadastro de nome (US01)**: o nome real agora é salvo no backend (`first_name`) e exibido nos dashboards, em vez do email. Corrige regressão em que o nome composto era perdido.
- **Sufixos na paleta (US17)**: `MorfemaListView` sem paginação — a paleta sempre recebe o catálogo completo. Os sufixos sumiam porque, ordenados por último, caíam fora da página 1 do DRF (`PAGE_SIZE=10`) quando o catálogo passava de 10 morfemas.
- **Painel do professor (US24/US25)**: novo endpoint `/api/professor/relatorio/` com dados reais de `Tentativa` (taxa de acerto, ranking de palavras mais erradas, desempenho por aluno, RN02 respeitado). Dashboard passa a consumir a API no lugar dos dados mock; UI mock de turmas (sem RF/backend) removida.
- **Redefinição de senha (US03)**: endpoint `/auth/reset-password/` (token temporário e de uso único) + tela `/reset-senha`. Link do email usa hash-route para funcionar em SPA estática sem rewrite no servidor.
- **Área de aprendizado (RF19)**: aulas com conteúdo morfológico real e expansível.

## Fora de escopo / não tocado
- Nenhuma alteração em `settings.py`, portas, CORS, URLs de deploy, `vite.config.ts` ou lógica de baseURL do `api.ts`.

## Observações para o time
- Os testes em `quickstart/tests.py` importam `from validador.services import validar_palavra`, mas **não existe módulo `validador`** no repo — provavelmente deixando a CI vermelha (fora do escopo desta PR).

## Test plan
- [ ] Cadastro com nome composto → nome aparece no dashboard
- [ ] Paleta de blocos exibe prefixos, radicais **e sufixos** com catálogo > 10 morfemas
- [ ] Painel do professor carrega métricas reais e ranking de palavras erradas
- [ ] Fluxo de reset: solicitar email → abrir link → definir nova senha → logar
- [ ] Área de aprendizado abre o conteúdo das aulas