### PR TITLE
feat: histórico real, turmas e atividades/quiz (RF21, RF23/RF24, RF12/RF16)

### DIFF
--- a/backend/core/admin.py
+++ b/backend/core/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
-from core.models import Usuario, Morfema, PalavraValida, Turma
+from core.models import Usuario, Morfema, PalavraValida, Turma, Atividade, Pergunta
 
 
 @admin.register(Usuario)
@@ -15,6 +15,19 @@ class UsuarioAdmin(UserAdmin):
 class TurmaAdmin(admin.ModelAdmin):
     list_display = ("nome", "serie", "professor", "criada_em")
     search_fields = ("nome",)
+
+
+class PerguntaInline(admin.TabularInline):
+    model = Pergunta
+    extra = 1
+
+
+@admin.register(Atividade)
+class AtividadeAdmin(admin.ModelAdmin):
+    list_display = ("titulo", "tipo", "nivel", "ativa", "criada_em")
+    list_filter = ("tipo", "nivel", "ativa")
+    search_fields = ("titulo",)
+    inlines = [PerguntaInline]
 
 
 @admin.register(Morfema)

--- a/backend/core/admin.py
+++ b/backend/core/admin.py
@@ -1,14 +1,20 @@
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
-from core.models import Usuario, Morfema, PalavraValida
+from core.models import Usuario, Morfema, PalavraValida, Turma
 
 
 @admin.register(Usuario)
 class UsuarioAdmin(UserAdmin):
-    list_display = ("email", "username", "tipo", "is_staff")
-    list_filter = ("tipo", "is_staff", "is_active")
+    list_display = ("email", "username", "tipo", "turma", "is_staff")
+    list_filter = ("tipo", "turma", "is_staff", "is_active")
     search_fields = ("email", "username")
     ordering = ("email",)
+
+
+@admin.register(Turma)
+class TurmaAdmin(admin.ModelAdmin):
+    list_display = ("nome", "serie", "professor", "criada_em")
+    search_fields = ("nome",)
 
 
 @admin.register(Morfema)

--- a/backend/core/migrations/0007_turma_usuario_turma.py
+++ b/backend/core/migrations/0007_turma_usuario_turma.py
@@ -1,0 +1,42 @@
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ("core", "0006_usuario_padrao"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="Turma",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("nome", models.CharField(max_length=100)),
+                ("serie", models.CharField(blank=True, max_length=50)),
+                ("criada_em", models.DateTimeField(auto_now_add=True)),
+                (
+                    "professor",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="turmas_lecionadas",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+            ],
+        ),
+        migrations.AddField(
+            model_name="usuario",
+            name="turma",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="alunos",
+                to="core.turma",
+            ),
+        ),
+    ]

--- a/backend/core/migrations/0008_atividade_pergunta.py
+++ b/backend/core/migrations/0008_atividade_pergunta.py
@@ -1,0 +1,42 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("core", "0007_turma_usuario_turma"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="Atividade",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("titulo", models.CharField(max_length=120)),
+                ("tipo", models.CharField(choices=[("quiz", "Quiz"), ("montagem", "Montagem de palavras")], default="quiz", max_length=10)),
+                ("nivel", models.PositiveIntegerField(default=1)),
+                ("ativa", models.BooleanField(default=True)),
+                ("criada_em", models.DateTimeField(auto_now_add=True)),
+            ],
+        ),
+        migrations.CreateModel(
+            name="Pergunta",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("enunciado", models.CharField(max_length=300)),
+                ("alternativas", models.JSONField(default=list)),
+                ("correta", models.PositiveIntegerField(default=0)),
+                ("explicacao", models.CharField(blank=True, max_length=500)),
+                ("topico", models.CharField(blank=True, max_length=50)),
+                (
+                    "atividade",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="perguntas",
+                        to="core.atividade",
+                    ),
+                ),
+            ],
+        ),
+    ]

--- a/backend/core/migrations/0009_seed_quiz.py
+++ b/backend/core/migrations/0009_seed_quiz.py
@@ -1,0 +1,118 @@
+from django.db import migrations
+
+
+QUIZZES = [
+    {
+        "titulo": "Quiz de Morfologia — Nível 1",
+        "nivel": 1,
+        "perguntas": [
+            {
+                "enunciado": 'Qual é o prefixo da palavra "infeliz"?',
+                "alternativas": ["in-", "feliz", "-iz", "fel-"],
+                "correta": 0,
+                "explicacao": 'O prefixo "in-" indica negação, transformando "feliz" em "infeliz".',
+                "topico": "Prefixos",
+            },
+            {
+                "enunciado": 'A palavra "amorzinho" possui qual sufixo?',
+                "alternativas": ["-or", "-inho", "amor-", "-zi"],
+                "correta": 1,
+                "explicacao": 'O sufixo "-inho" indica diminutivo ou afetividade.',
+                "topico": "Sufixos",
+            },
+            {
+                "enunciado": 'Qual é o radical da palavra "pedreiro"?',
+                "alternativas": ["-eiro", "pe-", "pedr-", "-dre"],
+                "correta": 2,
+                "explicacao": 'O radical "pedr-" carrega o significado básico da palavra.',
+                "topico": "Radicais",
+            },
+            {
+                "enunciado": 'A palavra "desleal" é formada por:',
+                "alternativas": ["Prefixo + Radical", "Radical + Sufixo", "Só Radical", "Dois Radicais"],
+                "correta": 0,
+                "explicacao": 'O prefixo "des-" indica negação somado ao radical "leal".',
+                "topico": "Derivação",
+            },
+            {
+                "enunciado": 'A palavra "guarda-chuva" é um exemplo de:',
+                "alternativas": ["Derivação", "Composição", "Prefixação", "Sufixação"],
+                "correta": 1,
+                "explicacao": "A composição une duas palavras independentes para formar uma nova.",
+                "topico": "Composição",
+            },
+        ],
+    },
+    {
+        "titulo": "Quiz de Morfologia — Nível 2",
+        "nivel": 2,
+        "perguntas": [
+            {
+                "enunciado": 'A palavra "infelizmente" é formada por:',
+                "alternativas": ["Prefixo + Radical", "Radical + Sufixo", "Prefixo + Radical + Sufixo", "Dois Radicais + Sufixo"],
+                "correta": 2,
+                "explicacao": '"in-" (prefixo) + "feliz" (radical) + "-mente" (sufixo): derivação prefixal e sufixal.',
+                "topico": "Derivação",
+            },
+            {
+                "enunciado": "Qual palavra abaixo é formada por composição por aglutinação?",
+                "alternativas": ["guarda-chuva", "planalto", "passatempo", "beija-flor"],
+                "correta": 1,
+                "explicacao": '"Planalto" (plano + alto) é aglutinação, pois há fusão e perda fonética.',
+                "topico": "Composição",
+            },
+            {
+                "enunciado": 'O morfema "-ável" em "amável" é classificado como:',
+                "alternativas": ["Sufixo nominal", "Sufixo verbal", "Sufixo adjetival", "Desinência"],
+                "correta": 2,
+                "explicacao": 'O sufixo "-ável" forma adjetivos a partir de verbos, indicando possibilidade.',
+                "topico": "Sufixos",
+            },
+            {
+                "enunciado": 'Em "desencanto", quantos morfemas existem?',
+                "alternativas": ["1", "2", "3", "4"],
+                "correta": 2,
+                "explicacao": '"des-" (prefixo) + "en-" (prefixo) + "canto" (radical) = 3 morfemas.',
+                "topico": "Prefixos",
+            },
+            {
+                "enunciado": 'A vogal temática de "cantar" é:',
+                "alternativas": ["c", "a", "n", "r"],
+                "correta": 1,
+                "explicacao": 'A vogal temática "a" indica que o verbo pertence à 1ª conjugação.',
+                "topico": "Radicais",
+            },
+        ],
+    },
+]
+
+
+def popular_quiz(apps, schema_editor):
+    Atividade = apps.get_model("core", "Atividade")
+    Pergunta = apps.get_model("core", "Pergunta")
+
+    for quiz in QUIZZES:
+        atividade = Atividade.objects.create(
+            titulo=quiz["titulo"],
+            tipo="quiz",
+            nivel=quiz["nivel"],
+            ativa=True,
+        )
+        for p in quiz["perguntas"]:
+            Pergunta.objects.create(atividade=atividade, **p)
+
+
+def remover_quiz(apps, schema_editor):
+    Atividade = apps.get_model("core", "Atividade")
+    Atividade.objects.filter(tipo="quiz", titulo__startswith="Quiz de Morfologia").delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("core", "0008_atividade_pergunta"),
+    ]
+
+    operations = [
+        migrations.RunPython(popular_quiz, remover_quiz),
+    ]

--- a/backend/core/migrations/0010_seed_atividades_morfologia.py
+++ b/backend/core/migrations/0010_seed_atividades_morfologia.py
@@ -1,0 +1,224 @@
+from django.db import migrations
+
+
+QUIZZES = [
+    {"titulo": "Quiz: Radicais (verbos)", "nivel": 1, "perguntas": [   {   'alternativas': ['am-', 'ger-', 'viv-', 'convenc-'],
+        'correta': 0,
+        'enunciado': 'Qual é o radical da palavra "amar"?',
+        'explicacao': 'O radical de "amar" é "am-", a parte que carrega o significado básico.',
+        'topico': 'Radicais'},
+    {   'alternativas': ['program-', 'and-', 'constru-', 'consum-'],
+        'correta': 1,
+        'enunciado': 'Qual é o radical da palavra "andar"?',
+        'explicacao': 'O radical de "andar" é "and-", a parte que carrega o significado básico.',
+        'topico': 'Radicais'},
+    {   'alternativas': ['ganh-', 'implod-', 'ajud-', 'antev-'],
+        'correta': 2,
+        'enunciado': 'Qual é o radical da palavra "ajudar"?',
+        'explicacao': 'O radical de "ajudar" é "ajud-", a parte que carrega o significado básico.',
+        'topico': 'Radicais'},
+    {   'alternativas': ['merec-', 'met-', 'gost-', 'aplic-'],
+        'correta': 3,
+        'enunciado': 'Qual é o radical da palavra "aplicar"?',
+        'explicacao': 'O radical de "aplicar" é "aplic-", a parte que carrega o significado '
+                      'básico.',
+        'topico': 'Radicais'},
+    {   'alternativas': ['pass-', 'rev-', 'estend-', 'arrum-'],
+        'correta': 3,
+        'enunciado': 'Qual é o radical da palavra "arrumar"?',
+        'explicacao': 'O radical de "arrumar" é "arrum-", a parte que carrega o significado '
+                      'básico.',
+        'topico': 'Radicais'},
+    {   'alternativas': ['atac-', 'aprend-', 'sort-', 'repet-'],
+        'correta': 0,
+        'enunciado': 'Qual é o radical da palavra "atacar"?',
+        'explicacao': 'O radical de "atacar" é "atac-", a parte que carrega o significado básico.',
+        'topico': 'Radicais'},
+    {   'alternativas': ['infer-', 'baix-', 'transfer-', 'estud-'],
+        'correta': 1,
+        'enunciado': 'Qual é o radical da palavra "baixar"?',
+        'explicacao': 'O radical de "baixar" é "baix-", a parte que carrega o significado básico.',
+        'topico': 'Radicais'},
+    {   'alternativas': ['brinc-', 'interv-', 'varr-', 'lamb-'],
+        'correta': 0,
+        'enunciado': 'Qual é o radical da palavra "brincar"?',
+        'explicacao': 'O radical de "brincar" é "brinc-", a parte que carrega o significado '
+                      'básico.',
+        'topico': 'Radicais'},
+    {   'alternativas': ['cant-', 'compet-', 'us-', 'merec-'],
+        'correta': 0,
+        'enunciado': 'Qual é o radical da palavra "cantar"?',
+        'explicacao': 'O radical de "cantar" é "cant-", a parte que carrega o significado básico.',
+        'topico': 'Radicais'},
+    {   'alternativas': ['cas-', 'descans-', 'olh-', 'prov-'],
+        'correta': 0,
+        'enunciado': 'Qual é o radical da palavra "casar"?',
+        'explicacao': 'O radical de "casar" é "cas-", a parte que carrega o significado básico.',
+        'topico': 'Radicais'}]},
+    {"titulo": "Quiz: Vogal Temática", "nivel": 1, "perguntas": [   {   'alternativas': ['a', 'e', 'i', '∅ (nenhuma)'],
+        'correta': 0,
+        'enunciado': 'Qual é a vogal temática em "amar"?',
+        'explicacao': 'A vogal temática de "amar" é "a".',
+        'topico': 'Vogal Temática'},
+    {   'alternativas': ['a', 'e', 'i', '∅ (nenhuma)'],
+        'correta': 2,
+        'enunciado': 'Qual é a vogal temática em "abrir"?',
+        'explicacao': 'A vogal temática de "abrir" é "i".',
+        'topico': 'Vogal Temática'},
+    {   'alternativas': ['a', 'e', 'i', '∅ (nenhuma)'],
+        'correta': 3,
+        'enunciado': 'Qual é a vogal temática em "hospitalizo"?',
+        'explicacao': 'A vogal temática de "hospitalizo" é "∅ (nenhuma)".',
+        'topico': 'Vogal Temática'},
+    {   'alternativas': ['a', 'e', 'i', '∅ (nenhuma)'],
+        'correta': 0,
+        'enunciado': 'Qual é a vogal temática em "andar"?',
+        'explicacao': 'A vogal temática de "andar" é "a".',
+        'topico': 'Vogal Temática'},
+    {   'alternativas': ['a', 'e', 'i', '∅ (nenhuma)'],
+        'correta': 2,
+        'enunciado': 'Qual é a vogal temática em "admitir"?',
+        'explicacao': 'A vogal temática de "admitir" é "i".',
+        'topico': 'Vogal Temática'},
+    {   'alternativas': ['a', 'e', 'i', '∅ (nenhuma)'],
+        'correta': 3,
+        'enunciado': 'Qual é a vogal temática em "festejo"?',
+        'explicacao': 'A vogal temática de "festejo" é "∅ (nenhuma)".',
+        'topico': 'Vogal Temática'},
+    {   'alternativas': ['a', 'e', 'i', '∅ (nenhuma)'],
+        'correta': 0,
+        'enunciado': 'Qual é a vogal temática em "ajudar"?',
+        'explicacao': 'A vogal temática de "ajudar" é "a".',
+        'topico': 'Vogal Temática'},
+    {   'alternativas': ['a', 'e', 'i', '∅ (nenhuma)'],
+        'correta': 2,
+        'enunciado': 'Qual é a vogal temática em "advir"?',
+        'explicacao': 'A vogal temática de "advir" é "i".',
+        'topico': 'Vogal Temática'},
+    {   'alternativas': ['a', 'e', 'i', '∅ (nenhuma)'],
+        'correta': 3,
+        'enunciado': 'Qual é a vogal temática em "saltito"?',
+        'explicacao': 'A vogal temática de "saltito" é "∅ (nenhuma)".',
+        'topico': 'Vogal Temática'},
+    {   'alternativas': ['a', 'e', 'i', '∅ (nenhuma)'],
+        'correta': 0,
+        'enunciado': 'Qual é a vogal temática em "aplicar"?',
+        'explicacao': 'A vogal temática de "aplicar" é "a".',
+        'topico': 'Vogal Temática'}]},
+    {"titulo": "Quiz: Sufixos derivacionais (denominais)", "nivel": 2, "perguntas": [   {   'alternativas': ['-iz-', '-ej-', '-it-', '-inho-'],
+        'correta': 0,
+        'enunciado': 'Qual é o sufixo que forma o verbo denominal "hospitalizar"?',
+        'explicacao': 'O verbo "hospitalizar" é formado pelo sufixo derivacional "-iz-".',
+        'topico': 'Sufixos'},
+    {   'alternativas': ['-iz-', '-ej-', '-it-', '-inho-'],
+        'correta': 0,
+        'enunciado': 'Qual é o sufixo que forma o verbo denominal "socializar"?',
+        'explicacao': 'O verbo "socializar" é formado pelo sufixo derivacional "-iz-".',
+        'topico': 'Sufixos'},
+    {   'alternativas': ['-iz-', '-ej-', '-it-', '-inho-'],
+        'correta': 0,
+        'enunciado': 'Qual é o sufixo que forma o verbo denominal "realizar"?',
+        'explicacao': 'O verbo "realizar" é formado pelo sufixo derivacional "-iz-".',
+        'topico': 'Sufixos'},
+    {   'alternativas': ['-iz-', '-ej-', '-it-', '-inho-'],
+        'correta': 0,
+        'enunciado': 'Qual é o sufixo que forma o verbo denominal "finalizar"?',
+        'explicacao': 'O verbo "finalizar" é formado pelo sufixo derivacional "-iz-".',
+        'topico': 'Sufixos'},
+    {   'alternativas': ['-iz-', '-ej-', '-it-', '-inho-'],
+        'correta': 0,
+        'enunciado': 'Qual é o sufixo que forma o verbo denominal "modernizar"?',
+        'explicacao': 'O verbo "modernizar" é formado pelo sufixo derivacional "-iz-".',
+        'topico': 'Sufixos'},
+    {   'alternativas': ['-iz-', '-ej-', '-it-', '-inho-'],
+        'correta': 1,
+        'enunciado': 'Qual é o sufixo que forma o verbo denominal "festejar"?',
+        'explicacao': 'O verbo "festejar" é formado pelo sufixo derivacional "-ej-".',
+        'topico': 'Sufixos'},
+    {   'alternativas': ['-iz-', '-ej-', '-it-', '-inho-'],
+        'correta': 2,
+        'enunciado': 'Qual é o sufixo que forma o verbo denominal "saltitar"?',
+        'explicacao': 'O verbo "saltitar" é formado pelo sufixo derivacional "-it-".',
+        'topico': 'Sufixos'},
+    {   'alternativas': ['-iz-', '-ej-', '-it-', '-inho-'],
+        'correta': 2,
+        'enunciado': 'Qual é o sufixo que forma o verbo denominal "dormitar"?',
+        'explicacao': 'O verbo "dormitar" é formado pelo sufixo derivacional "-it-".',
+        'topico': 'Sufixos'}]},
+]
+
+MORFEMAS = [   ('central', 'radical', 'bg-blue-600'),
+    ('cristal', 'radical', 'bg-blue-600'),
+    ('fest', 'radical', 'bg-blue-600'),
+    ('final', 'radical', 'bg-blue-600'),
+    ('formal', 'radical', 'bg-blue-600'),
+    ('global', 'radical', 'bg-blue-600'),
+    ('hospital', 'radical', 'bg-blue-600'),
+    ('legal', 'radical', 'bg-blue-600'),
+    ('modern', 'radical', 'bg-blue-600'),
+    ('real', 'radical', 'bg-blue-600'),
+    ('social', 'radical', 'bg-blue-600'),
+    ('iz', 'sufixo', 'bg-yellow-500'),
+    ('ej', 'sufixo', 'bg-yellow-500'),
+    ('ar', 'sufixo', 'bg-yellow-500')]
+
+PALAVRAS = [   ('hospitalizar', 'Derivação denominal (hospital + iz + ar)'),
+    ('socializar', 'Derivação denominal (social + iz + ar)'),
+    ('centralizar', 'Derivação denominal (central + iz + ar)'),
+    ('cristalizar', 'Derivação denominal (cristal + iz + ar)'),
+    ('finalizar', 'Derivação denominal (final + iz + ar)'),
+    ('legalizar', 'Derivação denominal (legal + iz + ar)'),
+    ('realizar', 'Derivação denominal (real + iz + ar)'),
+    ('modernizar', 'Derivação denominal (modern + iz + ar)'),
+    ('formalizar', 'Derivação denominal (formal + iz + ar)'),
+    ('globalizar', 'Derivação denominal (global + iz + ar)'),
+    ('festejar', 'Derivação denominal (fest + ej + ar)')]
+
+
+def popular(apps, schema_editor):
+    Atividade = apps.get_model("core", "Atividade")
+    Pergunta = apps.get_model("core", "Pergunta")
+    Morfema = apps.get_model("core", "Morfema")
+    PalavraValida = apps.get_model("core", "PalavraValida")
+
+    for quiz in QUIZZES:
+        atividade = Atividade.objects.create(
+            titulo=quiz["titulo"], tipo="quiz", nivel=quiz["nivel"], ativa=True
+        )
+        for p in quiz["perguntas"]:
+            Pergunta.objects.create(atividade=atividade, **p)
+
+    # Atividade de montagem (catálogo); o jogo de blocos usa o catálogo global.
+    Atividade.objects.create(
+        titulo="Montagem: verbos denominais", tipo="montagem", nivel=1, ativa=True
+    )
+
+    for texto, tipo, cor in MORFEMAS:
+        Morfema.objects.get_or_create(texto=texto, tipo=tipo, defaults={"cor": cor})
+
+    for texto, processo in PALAVRAS:
+        PalavraValida.objects.get_or_create(
+            texto=texto, defaults={"processo_morfologico": processo}
+        )
+
+
+def remover(apps, schema_editor):
+    Atividade = apps.get_model("core", "Atividade")
+    Morfema = apps.get_model("core", "Morfema")
+    PalavraValida = apps.get_model("core", "PalavraValida")
+
+    titulos = [q["titulo"] for q in QUIZZES] + ["Montagem: verbos denominais"]
+    Atividade.objects.filter(titulo__in=titulos).delete()
+    Morfema.objects.filter(texto__in=[m[0] for m in MORFEMAS]).delete()
+    PalavraValida.objects.filter(texto__in=[p[0] for p in PALAVRAS]).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("core", "0009_seed_quiz"),
+    ]
+
+    operations = [
+        migrations.RunPython(popular, remover),
+    ]

--- a/backend/core/models.py
+++ b/backend/core/models.py
@@ -70,6 +70,42 @@ class PalavraValida(models.Model):
 
 
 
+class Atividade(models.Model):
+    QUIZ = "quiz"
+    MONTAGEM = "montagem"
+    TIPO_CHOICES = [
+        (QUIZ, "Quiz"),
+        (MONTAGEM, "Montagem de palavras"),
+    ]
+
+    titulo = models.CharField(max_length=120)
+    tipo = models.CharField(max_length=10, choices=TIPO_CHOICES, default=QUIZ)
+    nivel = models.PositiveIntegerField(default=1)
+    ativa = models.BooleanField(default=True)
+    criada_em = models.DateTimeField(auto_now_add=True)
+
+    def __str__(self):
+        return f"{self.titulo} (nível {self.nivel})"
+
+
+class Pergunta(models.Model):
+    atividade = models.ForeignKey(
+        Atividade,
+        on_delete=models.CASCADE,
+        related_name="perguntas",
+    )
+    enunciado = models.CharField(max_length=300)
+    # Lista de strings com as alternativas.
+    alternativas = models.JSONField(default=list)
+    # Índice (0-based) da alternativa correta dentro de "alternativas".
+    correta = models.PositiveIntegerField(default=0)
+    explicacao = models.CharField(max_length=500, blank=True)
+    topico = models.CharField(max_length=50, blank=True)
+
+    def __str__(self):
+        return self.enunciado[:50]
+
+
 class Tentativa(models.Model):
     usuario = models.ForeignKey(Usuario, on_delete=models.CASCADE, related_name="tentativas")
     palavra = models.CharField(max_length=100)

--- a/backend/core/models.py
+++ b/backend/core/models.py
@@ -12,12 +12,34 @@ class Usuario(AbstractUser):
 
     email = models.EmailField(unique=True)
     tipo = models.CharField(max_length=10, choices=TIPO_CHOICES, default=ALUNO)
+    # Turma à qual o aluno pertence (RF23). Nulo para professores/admins.
+    turma = models.ForeignKey(
+        "Turma",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="alunos",
+    )
 
     USERNAME_FIELD = "email"
     REQUIRED_FIELDS = ["username"]
 
     def __str__(self):
         return self.email
+
+
+class Turma(models.Model):
+    nome = models.CharField(max_length=100)
+    serie = models.CharField(max_length=50, blank=True)
+    professor = models.ForeignKey(
+        Usuario,
+        on_delete=models.CASCADE,
+        related_name="turmas_lecionadas",
+    )
+    criada_em = models.DateTimeField(auto_now_add=True)
+
+    def __str__(self):
+        return self.nome
 
 
 class Morfema(models.Model):

--- a/backend/core/serializers.py
+++ b/backend/core/serializers.py
@@ -1,5 +1,5 @@
 from rest_framework import serializers
-from core.models import Usuario, Morfema, Turma
+from core.models import Usuario, Morfema, Turma, Atividade, Pergunta
 
 
 class UsuarioSerializer(serializers.ModelSerializer):
@@ -22,6 +22,28 @@ class TurmaSerializer(serializers.ModelSerializer):
         model = Turma
         fields = ["id", "nome", "serie", "criada_em", "total_alunos"]
         read_only_fields = ["id", "criada_em", "total_alunos"]
+
+
+class AtividadeSerializer(serializers.ModelSerializer):
+    """Resumo da atividade para listagem."""
+
+    class Meta:
+        model = Atividade
+        fields = ["id", "titulo", "tipo", "nivel"]
+
+
+class PerguntaSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Pergunta
+        fields = ["id", "enunciado", "alternativas", "correta", "explicacao", "topico"]
+
+
+class AtividadeDetailSerializer(serializers.ModelSerializer):
+    perguntas = PerguntaSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = Atividade
+        fields = ["id", "titulo", "tipo", "nivel", "perguntas"]
 
 
 class BlocoSerializer(serializers.Serializer):

--- a/backend/core/serializers.py
+++ b/backend/core/serializers.py
@@ -1,5 +1,5 @@
 from rest_framework import serializers
-from core.models import Usuario, Morfema
+from core.models import Usuario, Morfema, Turma
 
 
 class UsuarioSerializer(serializers.ModelSerializer):
@@ -13,6 +13,15 @@ class MorfemaSerializer(serializers.ModelSerializer):
         model = Morfema
         fields = ["id", "texto", "tipo", "cor"]
 
+
+
+class TurmaSerializer(serializers.ModelSerializer):
+    total_alunos = serializers.IntegerField(source="alunos.count", read_only=True)
+
+    class Meta:
+        model = Turma
+        fields = ["id", "nome", "serie", "criada_em", "total_alunos"]
+        read_only_fields = ["id", "criada_em", "total_alunos"]
 
 
 class BlocoSerializer(serializers.Serializer):

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -10,6 +10,8 @@ from core.views import (
     RelatorioProfessorView,
     TurmaListCreateView,
     AdicionarAlunoTurmaView,
+    AtividadeListView,
+    AtividadeDetailView,
 )
 
 urlpatterns = [
@@ -19,6 +21,8 @@ urlpatterns = [
     path("auth/reset-password/", ResetPasswordConfirmView.as_view(), name="reset-password"),
     path("morfemas/", MorfemaListView.as_view(), name="morfemas"),
     path("validar-palavra/", ValidarPalavraView.as_view(), name="validar-palavra"),
+    path("atividades/", AtividadeListView.as_view(), name="atividades"),
+    path("atividades/<int:pk>/", AtividadeDetailView.as_view(), name="atividade-detalhe"),
     path("historico/", HistoricoAlunoView.as_view(), name="historico-aluno"),
     path("professor/relatorio/", RelatorioProfessorView.as_view(), name="relatorio-professor"),
     path("professor/turmas/", TurmaListCreateView.as_view(), name="turmas"),

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -6,6 +6,7 @@ from core.views import (
     ValidarPalavraView,
     ForgotPasswordView,
     ResetPasswordConfirmView,
+    HistoricoAlunoView,
     RelatorioProfessorView,
 )
 
@@ -16,6 +17,7 @@ urlpatterns = [
     path("auth/reset-password/", ResetPasswordConfirmView.as_view(), name="reset-password"),
     path("morfemas/", MorfemaListView.as_view(), name="morfemas"),
     path("validar-palavra/", ValidarPalavraView.as_view(), name="validar-palavra"),
+    path("historico/", HistoricoAlunoView.as_view(), name="historico-aluno"),
     path("professor/relatorio/", RelatorioProfessorView.as_view(), name="relatorio-professor"),
 ]
 

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -8,6 +8,8 @@ from core.views import (
     ResetPasswordConfirmView,
     HistoricoAlunoView,
     RelatorioProfessorView,
+    TurmaListCreateView,
+    AdicionarAlunoTurmaView,
 )
 
 urlpatterns = [
@@ -19,5 +21,7 @@ urlpatterns = [
     path("validar-palavra/", ValidarPalavraView.as_view(), name="validar-palavra"),
     path("historico/", HistoricoAlunoView.as_view(), name="historico-aluno"),
     path("professor/relatorio/", RelatorioProfessorView.as_view(), name="relatorio-professor"),
+    path("professor/turmas/", TurmaListCreateView.as_view(), name="turmas"),
+    path("professor/turmas/<int:turma_id>/alunos/", AdicionarAlunoTurmaView.as_view(), name="turma-add-aluno"),
 ]
 

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -78,6 +78,33 @@ class ValidarPalavraView(APIView):
         })
 
 
+class HistoricoAlunoView(APIView):
+    """Histórico de pontuações/tentativas do próprio aluno (US21)."""
+
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        tentativas = Tentativa.objects.filter(usuario=request.user).order_by("-data")
+        total = tentativas.count()
+        acertos = tentativas.filter(acertou=True).count()
+        itens = [
+            {
+                "id": t.id,
+                "palavra": t.palavra,
+                "acertou": t.acertou,
+                "data": t.data.isoformat(),
+            }
+            for t in tentativas[:50]
+        ]
+        return Response(
+            {
+                "total": total,
+                "acertos": acertos,
+                "itens": itens,
+            }
+        )
+
+
 class RelatorioProfessorView(APIView):
     """Relatório consolidado de desempenho para o professor (US24/US25).
 

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -1,7 +1,7 @@
 from rest_framework.views import APIView
 from rest_framework.response import Response
-from rest_framework.permissions import IsAuthenticated, AllowAny
-from rest_framework.generics import ListAPIView, CreateAPIView
+from rest_framework.permissions import IsAuthenticated, AllowAny, BasePermission
+from rest_framework.generics import ListAPIView, CreateAPIView, ListCreateAPIView
 from rest_framework import status
 
 from urllib.parse import urlsplit
@@ -14,13 +14,25 @@ from django.db.models import Count
 from django.utils.encoding import force_bytes
 from django.utils.http import urlsafe_base64_encode, urlsafe_base64_decode
 
-from core.models import Morfema, PalavraValida, Tentativa, Usuario
+from core.models import Morfema, PalavraValida, Tentativa, Usuario, Turma
 from core.serializers import (
     UsuarioSerializer,
     MorfemaSerializer,
     ValidarPalavraSerializer,
     RegistroSerializer,
+    TurmaSerializer,
 )
+
+
+class IsProfessor(BasePermission):
+    """Permite acesso apenas a usuários autenticados com perfil de professor."""
+
+    def has_permission(self, request, view):
+        return bool(
+            request.user
+            and request.user.is_authenticated
+            and getattr(request.user, "tipo", None) == Usuario.PROFESSOR
+        )
 
 
 class MeView(APIView):
@@ -105,24 +117,73 @@ class HistoricoAlunoView(APIView):
         )
 
 
+class TurmaListCreateView(ListCreateAPIView):
+    """Lista e cria turmas do professor logado (RF23)."""
+
+    serializer_class = TurmaSerializer
+    permission_classes = [IsProfessor]
+    pagination_class = None
+
+    def get_queryset(self):
+        return Turma.objects.filter(professor=self.request.user).order_by("nome")
+
+    def perform_create(self, serializer):
+        serializer.save(professor=self.request.user)
+
+
+class AdicionarAlunoTurmaView(APIView):
+    """Vincula um aluno (por email) a uma turma do professor (RF23)."""
+
+    permission_classes = [IsProfessor]
+
+    def post(self, request, turma_id):
+        try:
+            turma = Turma.objects.get(pk=turma_id, professor=request.user)
+        except Turma.DoesNotExist:
+            return Response(
+                {"detail": "Turma não encontrada."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        email = (request.data.get("email") or "").strip().lower()
+        try:
+            aluno = Usuario.objects.get(email=email, tipo=Usuario.ALUNO)
+        except Usuario.DoesNotExist:
+            return Response(
+                {"detail": "Nenhum aluno encontrado com esse email."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        aluno.turma = turma
+        aluno.save(update_fields=["turma"])
+        return Response(
+            {
+                "detail": "Aluno adicionado à turma.",
+                "aluno": {
+                    "id": aluno.id,
+                    "nome": aluno.first_name or aluno.username,
+                    "email": aluno.email,
+                },
+            }
+        )
+
+
 class RelatorioProfessorView(APIView):
     """Relatório consolidado de desempenho para o professor (US24/US25).
 
-    Agrega dados reais das Tentativas registradas. Visão geral (todos os
-    alunos), pois o domínio ainda não modela turmas.
+    Agrega dados reais das Tentativas. Aceita ?turma=<id> para filtrar por
+    turma; sem o filtro, considera todos os alunos (visão geral).
     """
 
-    permission_classes = [IsAuthenticated]
+    permission_classes = [IsProfessor]
 
     def get(self, request):
-        # RN02: apenas professores podem acessar relatórios consolidados.
-        if getattr(request.user, "tipo", None) != Usuario.PROFESSOR:
-            return Response(
-                {"detail": "Apenas professores podem acessar o relatório."},
-                status=status.HTTP_403_FORBIDDEN,
-            )
+        turma_id = request.query_params.get("turma")
 
         tentativas = Tentativa.objects.all()
+        if turma_id:
+            tentativas = tentativas.filter(usuario__turma_id=turma_id)
+
         total = tentativas.count()
         acertos = tentativas.filter(acertou=True).count()
         erros = total - acertos
@@ -137,9 +198,10 @@ class RelatorioProfessorView(APIView):
         )
 
         # US24 — desempenho individual de cada aluno.
-        alunos = Usuario.objects.filter(tipo=Usuario.ALUNO).order_by(
-            "first_name", "username"
-        )
+        alunos_qs = Usuario.objects.filter(tipo=Usuario.ALUNO)
+        if turma_id:
+            alunos_qs = alunos_qs.filter(turma_id=turma_id)
+        alunos = alunos_qs.order_by("first_name", "username")
         por_aluno = []
         for aluno in alunos:
             do_aluno = tentativas.filter(usuario=aluno)

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -1,7 +1,7 @@
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated, AllowAny, BasePermission
-from rest_framework.generics import ListAPIView, CreateAPIView, ListCreateAPIView
+from rest_framework.generics import ListAPIView, CreateAPIView, ListCreateAPIView, RetrieveAPIView
 from rest_framework import status
 
 from urllib.parse import urlsplit
@@ -14,13 +14,15 @@ from django.db.models import Count
 from django.utils.encoding import force_bytes
 from django.utils.http import urlsafe_base64_encode, urlsafe_base64_decode
 
-from core.models import Morfema, PalavraValida, Tentativa, Usuario, Turma
+from core.models import Morfema, PalavraValida, Tentativa, Usuario, Turma, Atividade
 from core.serializers import (
     UsuarioSerializer,
     MorfemaSerializer,
     ValidarPalavraSerializer,
     RegistroSerializer,
     TurmaSerializer,
+    AtividadeSerializer,
+    AtividadeDetailSerializer,
 )
 
 
@@ -88,6 +90,29 @@ class ValidarPalavraView(APIView):
             "palavra": palavra,
             "processo_morfologico": processo,
         })
+
+
+class AtividadeListView(ListAPIView):
+    """Lista atividades ativas (RF16). Filtra por ?tipo=quiz|montagem."""
+
+    serializer_class = AtividadeSerializer
+    permission_classes = [IsAuthenticated]
+    pagination_class = None
+
+    def get_queryset(self):
+        qs = Atividade.objects.filter(ativa=True).order_by("nivel", "titulo")
+        tipo = self.request.query_params.get("tipo")
+        if tipo:
+            qs = qs.filter(tipo=tipo)
+        return qs
+
+
+class AtividadeDetailView(RetrieveAPIView):
+    """Detalha uma atividade com suas perguntas (RF16)."""
+
+    queryset = Atividade.objects.filter(ativa=True)
+    serializer_class = AtividadeDetailSerializer
+    permission_classes = [IsAuthenticated]
 
 
 class HistoricoAlunoView(APIView):

--- a/frontend/src/app/components/ProfessorDashboard.tsx
+++ b/frontend/src/app/components/ProfessorDashboard.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router';
-import { Users, TrendingUp, Award, AlertCircle, LogOut, User, Loader2 } from 'lucide-react';
+import { Users, TrendingUp, Award, AlertCircle, LogOut, User, Loader2, Plus, GraduationCap, X } from 'lucide-react';
 import {
   BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Cell,
 } from 'recharts';
@@ -8,7 +8,7 @@ import { Logo } from './Logo';
 import { useAppState } from '../state/AppState';
 import { api } from '../../lib/api';
 
-// Formato cru vindo do backend (GET /api/professor/relatorio/).
+// Formatos crus vindos do backend.
 type PalavraErrada = { palavra: string; ocorrencias: number };
 type AlunoRelatorio = {
   id: number;
@@ -27,6 +27,7 @@ type Relatorio = {
   palavras_mais_erradas: PalavraErrada[];
   alunos: AlunoRelatorio[];
 };
+type Turma = { id: number; nome: string; serie: string; criada_em: string; total_alunos: number };
 
 // Classifica o status do aluno a partir do aproveitamento.
 function statusDoAluno(respondidas: number, pct: number) {
@@ -43,10 +44,40 @@ export function ProfessorDashboard() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
+  const [turmas, setTurmas] = useState<Turma[]>([]);
+  // null = visão geral (todas as turmas).
+  const [selectedTurma, setSelectedTurma] = useState<number | null>(null);
+  // Incrementado após criar turma / adicionar aluno para forçar recarga.
+  const [reloadTick, setReloadTick] = useState(0);
+
+  const [showTurmaModal, setShowTurmaModal] = useState(false);
+  const [showAlunoModal, setShowAlunoModal] = useState(false);
+  const [turmaNome, setTurmaNome] = useState('');
+  const [turmaSerie, setTurmaSerie] = useState('');
+  const [alunoEmail, setAlunoEmail] = useState('');
+  const [modalError, setModalError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  // Carrega as turmas do professor.
   useEffect(() => {
     let active = true;
     api
-      .get<Relatorio>('/professor/relatorio/')
+      .get<Turma[]>('/professor/turmas/')
+      .then(({ data }) => {
+        if (active) setTurmas(Array.isArray(data) ? data : []);
+      })
+      .catch((err) => console.error('Falha ao carregar turmas:', err));
+    return () => {
+      active = false;
+    };
+  }, [reloadTick]);
+
+  // Carrega o relatório (geral ou da turma selecionada).
+  useEffect(() => {
+    let active = true;
+    const url = selectedTurma ? `/professor/relatorio/?turma=${selectedTurma}` : '/professor/relatorio/';
+    api
+      .get<Relatorio>(url)
       .then(({ data }) => {
         if (active) setRelatorio(data);
       })
@@ -60,7 +91,45 @@ export function ProfessorDashboard() {
     return () => {
       active = false;
     };
-  }, []);
+  }, [selectedTurma, reloadTick]);
+
+  const handleCriarTurma = async () => {
+    if (!turmaNome.trim()) return;
+    setSaving(true);
+    setModalError(null);
+    try {
+      await api.post('/professor/turmas/', { nome: turmaNome.trim(), serie: turmaSerie.trim() });
+      setTurmaNome('');
+      setTurmaSerie('');
+      setShowTurmaModal(false);
+      setReloadTick((t) => t + 1);
+    } catch (err) {
+      console.error('Falha ao criar turma:', err);
+      setModalError('Não foi possível criar a turma. Tente novamente.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleAdicionarAluno = async () => {
+    if (!alunoEmail.trim() || !selectedTurma) return;
+    setSaving(true);
+    setModalError(null);
+    try {
+      await api.post(`/professor/turmas/${selectedTurma}/alunos/`, { email: alunoEmail.trim() });
+      setAlunoEmail('');
+      setShowAlunoModal(false);
+      setReloadTick((t) => t + 1);
+    } catch (err: unknown) {
+      const detail =
+        typeof err === 'object' && err !== null && 'response' in err
+          ? (err as { response?: { data?: { detail?: string } } }).response?.data?.detail
+          : undefined;
+      setModalError(detail ?? 'Não foi possível adicionar o aluno.');
+    } finally {
+      setSaving(false);
+    }
+  };
 
   const alunos = relatorio?.alunos ?? [];
   const palavrasErradas = relatorio?.palavras_mais_erradas ?? [];
@@ -95,6 +164,55 @@ export function ProfessorDashboard() {
       </header>
 
       <main className="max-w-7xl mx-auto px-3 sm:px-4 py-4 sm:py-8">
+        {/* Seletor de turma + ações */}
+        <div className="bg-white rounded-xl sm:rounded-2xl shadow-lg p-3 sm:p-5 mb-4 sm:mb-6 flex flex-col gap-3 sm:gap-4 md:flex-row md:items-center md:justify-between">
+          <div className="flex items-center gap-2 sm:gap-3 flex-wrap">
+            <GraduationCap className="w-5 h-5 sm:w-6 sm:h-6 text-blue-600" />
+            <span className="text-sm sm:text-base text-muted-foreground">Turma:</span>
+            <div className="flex flex-wrap gap-2">
+              <button
+                onClick={() => setSelectedTurma(null)}
+                className={`px-3 sm:px-4 py-1.5 sm:py-2 rounded-xl transition-all text-sm ${
+                  selectedTurma === null
+                    ? 'bg-gradient-to-r from-blue-600 to-blue-700 text-white shadow-md'
+                    : 'bg-gray-100 hover:bg-gray-200'
+                }`}
+              >
+                Geral
+              </button>
+              {turmas.map((t) => (
+                <button
+                  key={t.id}
+                  onClick={() => setSelectedTurma(t.id)}
+                  className={`px-3 sm:px-4 py-1.5 sm:py-2 rounded-xl transition-all text-sm ${
+                    selectedTurma === t.id
+                      ? 'bg-gradient-to-r from-blue-600 to-blue-700 text-white shadow-md'
+                      : 'bg-gray-100 hover:bg-gray-200'
+                  }`}
+                >
+                  {t.nome} ({t.total_alunos})
+                </button>
+              ))}
+            </div>
+          </div>
+          <div className="flex gap-2">
+            <button
+              onClick={() => { setModalError(null); setShowTurmaModal(true); }}
+              className="px-3 sm:px-4 py-2 bg-yellow-400 text-white rounded-xl hover:bg-yellow-500 transition-colors flex items-center gap-1.5 sm:gap-2 shadow-md text-sm sm:text-base"
+            >
+              <Plus className="w-4 h-4" /> Nova Turma
+            </button>
+            <button
+              onClick={() => { setModalError(null); setShowAlunoModal(true); }}
+              disabled={!selectedTurma}
+              title={!selectedTurma ? 'Selecione uma turma para adicionar alunos' : undefined}
+              className="px-3 sm:px-4 py-2 bg-blue-600 text-white rounded-xl hover:bg-blue-700 transition-colors flex items-center gap-1.5 sm:gap-2 shadow-md disabled:opacity-50 text-sm sm:text-base"
+            >
+              <Plus className="w-4 h-4" /> <span className="hidden sm:inline">Adicionar</span> Aluno
+            </button>
+          </div>
+        </div>
+
         {loading && (
           <div className="flex items-center justify-center gap-2 py-20 text-muted-foreground">
             <Loader2 className="w-6 h-6 animate-spin" /> Carregando relatório...
@@ -197,7 +315,7 @@ export function ProfessorDashboard() {
               <h3 className="text-base sm:text-xl mb-3 sm:mb-4">Acompanhamento dos Alunos</h3>
               {alunos.length === 0 ? (
                 <div className="text-center text-muted-foreground py-6 sm:py-8 text-sm">
-                  Nenhum aluno cadastrado ainda.
+                  {selectedTurma ? 'Nenhum aluno nesta turma ainda. Use "Adicionar Aluno".' : 'Nenhum aluno cadastrado ainda.'}
                 </div>
               ) : (
                 <>
@@ -279,6 +397,91 @@ export function ProfessorDashboard() {
           </>
         )}
       </main>
+
+      {/* Modal Nova Turma */}
+      {showTurmaModal && (
+        <Modal title="Criar Nova Turma" onClose={() => setShowTurmaModal(false)}>
+          <div className="space-y-4">
+            <div>
+              <label className="block mb-2 text-sm">Nome da Turma</label>
+              <input
+                value={turmaNome}
+                onChange={(e) => setTurmaNome(e.target.value)}
+                placeholder="Ex: 8º Ano C"
+                className="w-full px-4 py-3 bg-input-background rounded-lg border border-border focus:outline-none focus:ring-2 focus:ring-primary"
+              />
+            </div>
+            <div>
+              <label className="block mb-2 text-sm">Série (opcional)</label>
+              <input
+                value={turmaSerie}
+                onChange={(e) => setTurmaSerie(e.target.value)}
+                placeholder="Ex: 8º Ano"
+                className="w-full px-4 py-3 bg-input-background rounded-lg border border-border focus:outline-none focus:ring-2 focus:ring-primary"
+              />
+            </div>
+            {modalError && (
+              <div className="p-3 bg-red-50 border-l-4 border-red-500 rounded-lg text-sm text-red-700">{modalError}</div>
+            )}
+            <button
+              onClick={handleCriarTurma}
+              disabled={saving || !turmaNome.trim()}
+              className="w-full py-3 bg-primary text-white rounded-xl hover:bg-primary/90 transition-colors disabled:opacity-50 flex items-center justify-center gap-2"
+            >
+              {saving && <Loader2 className="w-5 h-5 animate-spin" />}
+              Criar Turma
+            </button>
+          </div>
+        </Modal>
+      )}
+
+      {/* Modal Adicionar Aluno */}
+      {showAlunoModal && (
+        <Modal title="Adicionar Aluno à Turma" onClose={() => setShowAlunoModal(false)}>
+          <div className="space-y-4">
+            <p className="text-sm text-muted-foreground">
+              Informe o email de um aluno já cadastrado para incluí-lo na turma selecionada.
+            </p>
+            <div>
+              <label className="block mb-2 text-sm">Email do aluno</label>
+              <input
+                type="email"
+                value={alunoEmail}
+                onChange={(e) => setAlunoEmail(e.target.value)}
+                placeholder="aluno@email.com"
+                className="w-full px-4 py-3 bg-input-background rounded-lg border border-border focus:outline-none focus:ring-2 focus:ring-primary"
+              />
+            </div>
+            {modalError && (
+              <div className="p-3 bg-red-50 border-l-4 border-red-500 rounded-lg text-sm text-red-700">{modalError}</div>
+            )}
+            <button
+              onClick={handleAdicionarAluno}
+              disabled={saving || !alunoEmail.trim()}
+              className="w-full py-3 bg-primary text-white rounded-xl hover:bg-primary/90 transition-colors disabled:opacity-50 flex items-center justify-center gap-2"
+            >
+              {saving && <Loader2 className="w-5 h-5 animate-spin" />}
+              Adicionar Aluno
+            </button>
+          </div>
+        </Modal>
+      )}
+    </div>
+  );
+}
+
+function Modal({ title, onClose, children }: { title: string; onClose: () => void; children: React.ReactNode }) {
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-end sm:items-center justify-center sm:p-4 z-50" onClick={onClose}>
+      <div className="bg-white rounded-t-2xl sm:rounded-2xl shadow-2xl p-5 sm:p-6 max-w-md w-full max-h-[90vh] overflow-y-auto" onClick={(e) => e.stopPropagation()}>
+        <div className="flex items-center justify-between mb-4">
+          <h3 className="text-lg sm:text-xl">{title}</h3>
+          <button onClick={onClose} className="text-muted-foreground hover:text-foreground">
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+        {children}
+      </div>
     </div>
   );
 }

--- a/frontend/src/app/components/QuestionsScreen.tsx
+++ b/frontend/src/app/components/QuestionsScreen.tsx
@@ -1,12 +1,12 @@
 import { useEffect, useState } from 'react';
 import { Link, useNavigate } from 'react-router';
-import { ArrowLeft, Check, X, Trophy, Sparkles, Loader2 } from 'lucide-react';
+import { ArrowLeft, Check, X, Trophy, Sparkles, Loader2, BookOpen } from 'lucide-react';
 import { api } from '../../lib/api';
 
 type Question = { question: string; topic: string; options: string[]; correct: number; explanation: string };
 
 // Formatos crus vindos do backend.
-type AtividadeResumo = { id: number; tipo: string; nivel: number };
+type AtividadeResumo = { id: number; titulo: string; tipo: string; nivel: number };
 type PerguntaApi = {
   id: number;
   enunciado: string;
@@ -15,22 +15,25 @@ type PerguntaApi = {
   explicacao: string;
   topico: string;
 };
-type AtividadeDetalhe = { id: number; perguntas: PerguntaApi[] };
+type AtividadeDetalhe = { id: number; titulo: string; perguntas: PerguntaApi[] };
 
 export function QuestionsScreen() {
-  const [level, setLevel] = useState<1 | 2>(1);
+  const navigate = useNavigate();
+
+  const [atividades, setAtividades] = useState<AtividadeResumo[]>([]);
+  const [atividadesProntas, setAtividadesProntas] = useState(false);
+
+  // Quiz selecionado (null = tela de seleção).
+  const [selectedId, setSelectedId] = useState<number | null>(null);
+  const [questions, setQuestions] = useState<Question[]>([]);
+  // Id da atividade à qual "questions" corresponde (null = nada carregado).
+  const [questionsFor, setQuestionsFor] = useState<number | null>(null);
+
   const [current, setCurrent] = useState(0);
   const [selected, setSelected] = useState<number | null>(null);
   const [showResult, setShowResult] = useState(false);
   const [score, setScore] = useState(0);
   const [finished, setFinished] = useState(false);
-  const navigate = useNavigate();
-
-  const [atividades, setAtividades] = useState<AtividadeResumo[]>([]);
-  const [atividadesProntas, setAtividadesProntas] = useState(false);
-  const [questions, setQuestions] = useState<Question[]>([]);
-  // Nível ao qual o "questions" carregado corresponde (null = nada carregado).
-  const [questionsLevel, setQuestionsLevel] = useState<number | null>(null);
 
   // Lista as atividades do tipo quiz uma vez.
   useEffect(() => {
@@ -49,14 +52,12 @@ export function QuestionsScreen() {
     };
   }, []);
 
-  const atividadeDoNivel = atividades.find((a) => a.nivel === level);
-
-  // Carrega as perguntas da atividade do nível selecionado.
+  // Carrega as perguntas do quiz selecionado.
   useEffect(() => {
-    if (!atividadeDoNivel) return;
+    if (selectedId === null) return;
     let active = true;
     api
-      .get<AtividadeDetalhe>(`/atividades/${atividadeDoNivel.id}/`)
+      .get<AtividadeDetalhe>(`/atividades/${selectedId}/`)
       .then(({ data }) => {
         if (!active) return;
         setQuestions(
@@ -68,29 +69,44 @@ export function QuestionsScreen() {
             explanation: p.explicacao,
           })),
         );
-        setQuestionsLevel(level);
+        setQuestionsFor(selectedId);
       })
       .catch((err) => console.error('Falha ao carregar perguntas:', err));
     return () => {
       active = false;
     };
-  }, [level, atividadeDoNivel]);
+  }, [selectedId]);
 
-  // Loading e disponibilidade derivados (sem setState em efeito).
-  const carregando = !atividadesProntas || (!!atividadeDoNivel && questionsLevel !== level);
-  const semQuiz =
-    atividadesProntas &&
-    (!atividadeDoNivel || (questionsLevel === level && questions.length === 0));
-
-  const q = questions[current];
-  const reset = (nextLevel: 1 | 2) => {
-    setLevel(nextLevel);
+  const escolherQuiz = (id: number) => {
+    setSelectedId(id);
     setCurrent(0);
     setSelected(null);
     setShowResult(false);
     setScore(0);
     setFinished(false);
   };
+
+  const voltarSelecao = () => {
+    setSelectedId(null);
+    setFinished(false);
+    setCurrent(0);
+    setSelected(null);
+    setShowResult(false);
+    setScore(0);
+  };
+
+  const tentarNovamente = () => {
+    setCurrent(0);
+    setSelected(null);
+    setShowResult(false);
+    setScore(0);
+    setFinished(false);
+  };
+
+  const q = questions[current];
+  const quizAtual = atividades.find((a) => a.id === selectedId);
+  const carregandoPerguntas = selectedId !== null && questionsFor !== selectedId;
+  const quizVazio = selectedId !== null && questionsFor === selectedId && questions.length === 0;
 
   const handleSelect = (idx: number) => {
     if (showResult || !q) return;
@@ -110,8 +126,53 @@ export function QuestionsScreen() {
     }
   };
 
-  // Estados de carregamento / quiz indisponível para o nível.
-  if (!finished && carregando) {
+  // -------- Tela de seleção de quiz --------
+  if (selectedId === null) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-blue-50 via-yellow-50 to-red-50 p-3 sm:p-4">
+        <div className="max-w-3xl mx-auto">
+          <div className="flex items-center justify-between mb-4 sm:mb-6 gap-2">
+            <Link to="/aluno/dashboard" className="flex items-center gap-1 sm:gap-2 text-muted-foreground hover:text-foreground shrink-0">
+              <ArrowLeft className="w-5 h-5" /> <span className="hidden sm:inline">Voltar</span>
+            </Link>
+            <h1 className="text-lg sm:text-2xl text-center">Escolha um Quiz</h1>
+            <div className="w-8 sm:w-20" />
+          </div>
+
+          {!atividadesProntas ? (
+            <div className="flex items-center justify-center gap-2 py-20 text-muted-foreground">
+              <Loader2 className="w-6 h-6 animate-spin" /> Carregando quizzes...
+            </div>
+          ) : atividades.length === 0 ? (
+            <div className="bg-white rounded-2xl shadow-xl p-6 sm:p-8 text-center">
+              <p className="text-sm sm:text-base text-muted-foreground">Nenhum quiz cadastrado ainda.</p>
+            </div>
+          ) : (
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 sm:gap-4">
+              {atividades.map((a) => (
+                <button
+                  key={a.id}
+                  onClick={() => escolherQuiz(a.id)}
+                  className="bg-white rounded-xl sm:rounded-2xl p-4 sm:p-6 shadow-lg hover:shadow-2xl hover:-translate-y-1 transition-all text-left border-2 border-transparent hover:border-blue-600 flex items-center gap-3"
+                >
+                  <div className="w-10 h-10 sm:w-12 sm:h-12 bg-gradient-to-br from-blue-600 to-blue-700 rounded-xl flex items-center justify-center shrink-0">
+                    <BookOpen className="w-5 h-5 sm:w-6 sm:h-6 text-white" />
+                  </div>
+                  <div className="min-w-0">
+                    <h2 className="text-base sm:text-lg truncate">{a.titulo}</h2>
+                    <span className="text-xs px-2 py-0.5 bg-blue-50 text-blue-700 rounded-full">Nível {a.nivel}</span>
+                  </div>
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  // -------- Carregando perguntas do quiz escolhido --------
+  if (!finished && carregandoPerguntas) {
     return (
       <div className="min-h-screen bg-gradient-to-br from-blue-50 via-yellow-50 to-red-50 flex items-center justify-center p-4">
         <div className="flex items-center gap-2 text-muted-foreground">
@@ -121,86 +182,59 @@ export function QuestionsScreen() {
     );
   }
 
-  if (!finished && semQuiz) {
+  // -------- Quiz sem perguntas --------
+  if (!finished && quizVazio) {
     return (
       <div className="min-h-screen bg-gradient-to-br from-blue-50 via-yellow-50 to-red-50 flex items-center justify-center p-4">
         <div className="bg-white rounded-2xl shadow-xl p-6 sm:p-8 max-w-md w-full text-center">
-          <h2 className="text-xl sm:text-2xl mb-2">Nenhuma pergunta disponível</h2>
+          <h2 className="text-xl sm:text-2xl mb-2">Quiz sem perguntas</h2>
           <p className="text-sm sm:text-base text-muted-foreground mb-6">
-            Ainda não há um quiz cadastrado para o Nível {level}.
+            Este quiz ainda não tem perguntas cadastradas.
           </p>
-          <div className="flex flex-col gap-3">
-            {level === 2 && (
-              <button onClick={() => reset(1)} className="w-full py-3 bg-yellow-400 text-white rounded-xl hover:bg-yellow-500 transition-colors">
-                Voltar ao Nível 1
-              </button>
-            )}
-            <button onClick={() => navigate('/aluno/dashboard')} className="w-full py-3 bg-primary text-white rounded-xl hover:bg-primary/90 transition-colors">
-              Voltar
-            </button>
-          </div>
+          <button onClick={voltarSelecao} className="w-full py-3 bg-primary text-white rounded-xl hover:bg-primary/90 transition-colors">
+            Escolher outro quiz
+          </button>
         </div>
       </div>
     );
   }
 
+  // -------- Tela de resultado --------
   if (finished) {
     const pct = (score / questions.length) * 100;
-    const unlockedLevel2 = level === 1 && pct >= 80;
     return (
       <div className="min-h-screen bg-gradient-to-br from-blue-50 via-yellow-50 to-red-50 flex items-center justify-center p-3 sm:p-4">
         <div className="bg-white rounded-2xl sm:rounded-3xl shadow-2xl p-5 sm:p-8 max-w-md w-full text-center">
-          <div className="w-18 h-18 sm:w-24 sm:h-24 bg-gradient-to-br from-yellow-400 to-yellow-500 rounded-full flex items-center justify-center mx-auto mb-4 sm:mb-6 shadow-xl" style={{ width: 'clamp(4.5rem, 15vw, 6rem)', height: 'clamp(4.5rem, 15vw, 6rem)' }}>
+          <div className="bg-gradient-to-br from-yellow-400 to-yellow-500 rounded-full flex items-center justify-center mx-auto mb-4 sm:mb-6 shadow-xl" style={{ width: 'clamp(4.5rem, 15vw, 6rem)', height: 'clamp(4.5rem, 15vw, 6rem)' }}>
             <Trophy className="w-8 h-8 sm:w-12 sm:h-12 text-white" />
           </div>
           <h2 className="text-2xl sm:text-3xl mb-2">Parabéns!</h2>
-          <p className="text-sm sm:text-base text-muted-foreground mb-4 sm:mb-6">Você concluiu o Nível {level}</p>
+          <p className="text-sm sm:text-base text-muted-foreground mb-4 sm:mb-6">Você concluiu "{quizAtual?.titulo}"</p>
           <div className="bg-gradient-to-br from-blue-50 to-yellow-50 rounded-xl sm:rounded-2xl p-4 sm:p-6 mb-4 sm:mb-6">
             <div className="text-4xl sm:text-5xl text-blue-600 mb-2">{score}/{questions.length}</div>
             <div className="text-sm sm:text-base text-muted-foreground">acertos ({pct.toFixed(0)}%)</div>
           </div>
-          {unlockedLevel2 && (
-            <div className="bg-gradient-to-r from-yellow-100 to-red-100 border-2 border-yellow-400 rounded-2xl p-4 mb-4">
-              <div className="text-yellow-700 mb-1">🔓 Nível 2 desbloqueado!</div>
-              <div className="text-xs text-muted-foreground">Você atingiu mais de 80% de acertos.</div>
-            </div>
-          )}
-          {level === 1 && !unlockedLevel2 && (
-            <div className="bg-blue-50 border border-blue-200 rounded-xl p-3 mb-4 text-sm text-muted-foreground">
-              Atinja 80% de acertos para desbloquear o Nível 2.
-            </div>
-          )}
           <div className="flex flex-col gap-3">
-            {unlockedLevel2 && (
-              <button
-                onClick={() => reset(2)}
-                className="w-full py-3 bg-gradient-to-r from-red-500 to-yellow-500 text-white rounded-xl hover:opacity-90 transition shadow-md"
-              >
-                Avançar para o Nível 2 →
-              </button>
-            )}
             <div className="flex gap-3">
               <button
-                onClick={() => reset(level)}
+                onClick={tentarNovamente}
                 className="flex-1 py-3 bg-yellow-400 text-white rounded-xl hover:bg-yellow-500 transition-colors shadow-md"
               >
                 Tentar Novamente
               </button>
               <button
-                onClick={() => navigate('/aluno/dashboard')}
+                onClick={voltarSelecao}
                 className="flex-1 py-3 bg-primary text-white rounded-xl hover:bg-primary/90 transition-colors shadow-md"
               >
-                Voltar
+                Outro Quiz
               </button>
             </div>
-            {level === 2 && (
-              <button
-                onClick={() => reset(1)}
-                className="w-full py-2 text-sm text-muted-foreground hover:text-foreground"
-              >
-                Voltar ao Nível 1
-              </button>
-            )}
+            <button
+              onClick={() => navigate('/aluno/dashboard')}
+              className="w-full py-2 text-sm text-muted-foreground hover:text-foreground"
+            >
+              Voltar ao início
+            </button>
           </div>
         </div>
       </div>
@@ -213,24 +247,11 @@ export function QuestionsScreen() {
     <div className="min-h-screen bg-gradient-to-br from-blue-50 via-yellow-50 to-red-50 p-3 sm:p-4">
       <div className="max-w-3xl mx-auto">
         <div className="flex items-center justify-between mb-4 sm:mb-6 gap-2">
-          <Link to="/aluno/dashboard" className="flex items-center gap-1 sm:gap-2 text-muted-foreground hover:text-foreground shrink-0">
-            <ArrowLeft className="w-5 h-5" /> <span className="hidden sm:inline">Voltar</span>
-          </Link>
-          <div className="flex items-center gap-2 sm:gap-3 text-sm">
-            <div className="flex rounded-full overflow-hidden border border-border bg-white shadow-sm">
-              <button
-                onClick={() => reset(1)}
-                className={`px-2 sm:px-3 py-1 transition-colors text-xs sm:text-sm ${level === 1 ? 'bg-blue-100 text-blue-700' : 'text-muted-foreground hover:bg-blue-50'}`}
-              >
-                Nível 1
-              </button>
-              <button
-                onClick={() => reset(2)}
-                className={`px-2 sm:px-3 py-1 transition-colors text-xs sm:text-sm ${level === 2 ? 'bg-red-100 text-red-700' : 'text-muted-foreground hover:bg-red-50'}`}
-              >
-                Nível 2
-              </button>
-            </div>
+          <button onClick={voltarSelecao} className="flex items-center gap-1 sm:gap-2 text-muted-foreground hover:text-foreground shrink-0">
+            <ArrowLeft className="w-5 h-5" /> <span className="hidden sm:inline">Quizzes</span>
+          </button>
+          <div className="flex items-center gap-2 sm:gap-3 text-sm min-w-0">
+            <span className="text-xs sm:text-sm text-muted-foreground truncate hidden sm:inline">{quizAtual?.titulo}</span>
             <span className="text-xs sm:text-sm text-muted-foreground whitespace-nowrap">
               {current + 1}/{questions.length}
             </span>

--- a/frontend/src/app/components/QuestionsScreen.tsx
+++ b/frontend/src/app/components/QuestionsScreen.tsx
@@ -1,86 +1,21 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Link, useNavigate } from 'react-router';
-import { ArrowLeft, Check, X, Trophy, Sparkles } from 'lucide-react';
-import { useAppState } from '../state/AppState';
-import type { Topic } from '../state/AppState';
+import { ArrowLeft, Check, X, Trophy, Sparkles, Loader2 } from 'lucide-react';
+import { api } from '../../lib/api';
 
-type Question = { question: string; topic: Topic; options: string[]; correct: number; explanation: string };
+type Question = { question: string; topic: string; options: string[]; correct: number; explanation: string };
 
-const questionsLevel2: Question[] = [
-  {
-    question: 'A palavra "infelizmente" é formada por:',
-    topic: 'Derivação',
-    options: ['Prefixo + Radical', 'Radical + Sufixo', 'Prefixo + Radical + Sufixo', 'Dois Radicais + Sufixo'],
-    correct: 2,
-    explanation: '"in-" (prefixo) + "feliz" (radical) + "-mente" (sufixo). É derivação prefixal e sufixal.',
-  },
-  {
-    question: 'Qual palavra abaixo é formada por composição por aglutinação?',
-    topic: 'Composição',
-    options: ['guarda-chuva', 'planalto', 'passatempo', 'beija-flor'],
-    correct: 1,
-    explanation: '"Planalto" (plano + alto) é aglutinação, pois há fusão e perda fonética. As demais são justaposição.',
-  },
-  {
-    question: 'O morfema "-ável" em "amável" é classificado como:',
-    topic: 'Sufixos',
-    options: ['Sufixo nominal', 'Sufixo verbal', 'Sufixo adjetival', 'Desinência'],
-    correct: 2,
-    explanation: 'O sufixo "-ável" forma adjetivos a partir de verbos, indicando possibilidade.',
-  },
-  {
-    question: 'Em "desencanto", quantos morfemas existem?',
-    topic: 'Prefixos',
-    options: ['1', '2', '3', '4'],
-    correct: 2,
-    explanation: '"des-" (prefixo) + "en-" (prefixo) + "canto" (radical) = 3 morfemas.',
-  },
-  {
-    question: 'A vogal temática de "cantar" é:',
-    topic: 'Radicais',
-    options: ['c', 'a', 'n', 'r'],
-    correct: 1,
-    explanation: 'A vogal temática "a" indica que o verbo pertence à 1ª conjugação.',
-  },
-];
-
-const questionsLevel1: Question[] = [
-  {
-    question: 'Qual é o prefixo da palavra "infeliz"?',
-    topic: 'Prefixos',
-    options: ['in-', 'feliz', '-iz', 'fel-'],
-    correct: 0,
-    explanation: 'O prefixo "in-" indica negação, transformando "feliz" em "infeliz".',
-  },
-  {
-    question: 'A palavra "amorzinho" possui qual sufixo?',
-    topic: 'Sufixos',
-    options: ['-or', '-inho', 'amor-', '-zi'],
-    correct: 1,
-    explanation: 'O sufixo "-inho" indica diminutivo ou afetividade.',
-  },
-  {
-    question: 'Qual é o radical da palavra "pedreiro"?',
-    topic: 'Radicais',
-    options: ['-eiro', 'pe-', 'pedr-', '-dre'],
-    correct: 2,
-    explanation: 'O radical "pedr-" é a parte que carrega o significado básico da palavra.',
-  },
-  {
-    question: 'A palavra "desleal" é formada por:',
-    topic: 'Derivação',
-    options: ['Prefixo + Radical', 'Radical + Sufixo', 'Só Radical', 'Dois Radicais'],
-    correct: 0,
-    explanation: 'O prefixo "des-" indica negação somado ao radical "leal".',
-  },
-  {
-    question: 'A palavra "guarda-chuva" é um exemplo de:',
-    topic: 'Composição',
-    options: ['Derivação', 'Composição', 'Prefixação', 'Sufixação'],
-    correct: 1,
-    explanation: 'A composição une duas palavras independentes para formar uma nova.',
-  },
-];
+// Formatos crus vindos do backend.
+type AtividadeResumo = { id: number; tipo: string; nivel: number };
+type PerguntaApi = {
+  id: number;
+  enunciado: string;
+  alternativas: string[];
+  correta: number;
+  explicacao: string;
+  topico: string;
+};
+type AtividadeDetalhe = { id: number; perguntas: PerguntaApi[] };
 
 export function QuestionsScreen() {
   const [level, setLevel] = useState<1 | 2>(1);
@@ -90,9 +25,63 @@ export function QuestionsScreen() {
   const [score, setScore] = useState(0);
   const [finished, setFinished] = useState(false);
   const navigate = useNavigate();
-  const { addHistory } = useAppState();
 
-  const questions = level === 1 ? questionsLevel1 : questionsLevel2;
+  const [atividades, setAtividades] = useState<AtividadeResumo[]>([]);
+  const [atividadesProntas, setAtividadesProntas] = useState(false);
+  const [questions, setQuestions] = useState<Question[]>([]);
+  // Nível ao qual o "questions" carregado corresponde (null = nada carregado).
+  const [questionsLevel, setQuestionsLevel] = useState<number | null>(null);
+
+  // Lista as atividades do tipo quiz uma vez.
+  useEffect(() => {
+    let active = true;
+    api
+      .get<AtividadeResumo[]>('/atividades/?tipo=quiz')
+      .then(({ data }) => {
+        if (active) setAtividades(Array.isArray(data) ? data : []);
+      })
+      .catch((err) => console.error('Falha ao carregar atividades:', err))
+      .finally(() => {
+        if (active) setAtividadesProntas(true);
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const atividadeDoNivel = atividades.find((a) => a.nivel === level);
+
+  // Carrega as perguntas da atividade do nível selecionado.
+  useEffect(() => {
+    if (!atividadeDoNivel) return;
+    let active = true;
+    api
+      .get<AtividadeDetalhe>(`/atividades/${atividadeDoNivel.id}/`)
+      .then(({ data }) => {
+        if (!active) return;
+        setQuestions(
+          data.perguntas.map((p) => ({
+            question: p.enunciado,
+            topic: p.topico,
+            options: p.alternativas,
+            correct: p.correta,
+            explanation: p.explicacao,
+          })),
+        );
+        setQuestionsLevel(level);
+      })
+      .catch((err) => console.error('Falha ao carregar perguntas:', err));
+    return () => {
+      active = false;
+    };
+  }, [level, atividadeDoNivel]);
+
+  // Loading e disponibilidade derivados (sem setState em efeito).
+  const carregando = !atividadesProntas || (!!atividadeDoNivel && questionsLevel !== level);
+  const semQuiz =
+    atividadesProntas &&
+    (!atividadeDoNivel || (questionsLevel === level && questions.length === 0));
+
   const q = questions[current];
   const reset = (nextLevel: 1 | 2) => {
     setLevel(nextLevel);
@@ -104,12 +93,11 @@ export function QuestionsScreen() {
   };
 
   const handleSelect = (idx: number) => {
-    if (showResult) return;
+    if (showResult || !q) return;
     const isCorrect = idx === q.correct;
     setSelected(idx);
     setShowResult(true);
     if (isCorrect) setScore(score + 1);
-    addHistory({ question: q.question, topic: q.topic, correct: isCorrect });
   };
 
   const handleNext = () => {
@@ -121,6 +109,40 @@ export function QuestionsScreen() {
       setShowResult(false);
     }
   };
+
+  // Estados de carregamento / quiz indisponível para o nível.
+  if (!finished && carregando) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-blue-50 via-yellow-50 to-red-50 flex items-center justify-center p-4">
+        <div className="flex items-center gap-2 text-muted-foreground">
+          <Loader2 className="w-6 h-6 animate-spin" /> Carregando perguntas...
+        </div>
+      </div>
+    );
+  }
+
+  if (!finished && semQuiz) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-blue-50 via-yellow-50 to-red-50 flex items-center justify-center p-4">
+        <div className="bg-white rounded-2xl shadow-xl p-6 sm:p-8 max-w-md w-full text-center">
+          <h2 className="text-xl sm:text-2xl mb-2">Nenhuma pergunta disponível</h2>
+          <p className="text-sm sm:text-base text-muted-foreground mb-6">
+            Ainda não há um quiz cadastrado para o Nível {level}.
+          </p>
+          <div className="flex flex-col gap-3">
+            {level === 2 && (
+              <button onClick={() => reset(1)} className="w-full py-3 bg-yellow-400 text-white rounded-xl hover:bg-yellow-500 transition-colors">
+                Voltar ao Nível 1
+              </button>
+            )}
+            <button onClick={() => navigate('/aluno/dashboard')} className="w-full py-3 bg-primary text-white rounded-xl hover:bg-primary/90 transition-colors">
+              Voltar
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   if (finished) {
     const pct = (score / questions.length) * 100;

--- a/frontend/src/app/components/StudentDashboard.tsx
+++ b/frontend/src/app/components/StudentDashboard.tsx
@@ -1,20 +1,42 @@
+import { useEffect, useState } from 'react';
 import { Link } from 'react-router';
 import { BookOpen, Puzzle, Trophy, Brain, LogOut, User, Check, X, History } from 'lucide-react';
 import { Logo } from './Logo';
 import { useAppState } from '../state/AppState';
+import { api } from '../../lib/api';
+
+// Formato cru vindo do backend (GET /api/historico/).
+type Tentativa = { id: number; palavra: string; acertou: boolean; data: string };
+type Historico = { total: number; acertos: number; itens: Tentativa[] };
 
 export function StudentDashboard() {
-  const { history, currentStudentId, usuario } = useAppState();
+  const { usuario } = useAppState();
   // Exibe o nome real (first_name); cai para username/email só se vazio.
   const studentName = usuario?.first_name?.trim() || usuario?.username || 'Aluno';
 
-  const myHistory = history.filter((h) => h.studentId === currentStudentId);
-  const totalAnswered = myHistory.length;
-  const correct = myHistory.filter((h) => h.correct).length;
+  const [historico, setHistorico] = useState<Historico | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    api
+      .get<Historico>('/historico/')
+      .then(({ data }) => {
+        if (active) setHistorico(data);
+      })
+      .catch((err) => {
+        console.error('Falha ao carregar histórico:', err);
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const totalAnswered = historico?.total ?? 0;
+  const correct = historico?.acertos ?? 0;
   const progress = totalAnswered ? Math.round((correct / totalAnswered) * 100) : 0;
   const points = correct * 50;
   const level = Math.max(1, Math.floor(correct / 3) + 1);
-  const recent = [...myHistory].reverse().slice(0, 6);
+  const recent = (historico?.itens ?? []).slice(0, 6);
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-blue-50 via-yellow-50 to-red-50">
@@ -133,28 +155,30 @@ export function StudentDashboard() {
             <div className="bg-gradient-to-r from-blue-600 to-blue-700 text-white p-3 sm:p-5 flex items-center gap-3">
               <History className="w-5 h-5 sm:w-6 sm:h-6" />
               <div>
-                <h3 className="text-base sm:text-lg">Histórico de Questões</h3>
+                <h3 className="text-base sm:text-lg">Histórico de Tentativas</h3>
                 <div className="text-xs opacity-90">Seu desempenho recente</div>
               </div>
             </div>
             <div className="p-3 sm:p-4 max-h-72 sm:max-h-96 overflow-y-auto">
               {recent.length === 0 ? (
                 <div className="text-center text-muted-foreground py-8 text-sm">
-                  Você ainda não respondeu nenhuma questão.
+                  Você ainda não fez nenhuma tentativa.
                 </div>
               ) : (
                 <ul className="space-y-2">
                   {recent.map((h) => (
-                    <li key={h.id} className={`p-3 rounded-lg border-l-4 ${h.correct ? 'bg-green-50 border-green-500' : 'bg-red-50 border-red-500'}`}>
+                    <li key={h.id} className={`p-3 rounded-lg border-l-4 ${h.acertou ? 'bg-green-50 border-green-500' : 'bg-red-50 border-red-500'}`}>
                       <div className="flex items-start gap-2">
-                        <div className={`w-6 h-6 rounded-full flex items-center justify-center flex-shrink-0 ${h.correct ? 'bg-green-500' : 'bg-red-500'}`}>
-                          {h.correct ? <Check className="w-4 h-4 text-white" /> : <X className="w-4 h-4 text-white" />}
+                        <div className={`w-6 h-6 rounded-full flex items-center justify-center flex-shrink-0 ${h.acertou ? 'bg-green-500' : 'bg-red-500'}`}>
+                          {h.acertou ? <Check className="w-4 h-4 text-white" /> : <X className="w-4 h-4 text-white" />}
                         </div>
                         <div className="min-w-0 flex-1">
-                          <div className="text-sm truncate">{h.question}</div>
+                          <div className="text-sm truncate">{h.palavra}</div>
                           <div className="flex items-center gap-2 mt-1">
-                            <span className="text-xs px-2 py-0.5 bg-white rounded-full text-muted-foreground">{h.topic}</span>
-                            <span className="text-xs text-muted-foreground">{h.date}</span>
+                            <span className="text-xs px-2 py-0.5 bg-white rounded-full text-muted-foreground">
+                              {h.acertou ? 'Válida' : 'Inválida'}
+                            </span>
+                            <span className="text-xs text-muted-foreground">{h.data.slice(0, 10)}</span>
                           </div>
                         </div>
                       </div>


### PR DESCRIPTION
## Resumo

Implementa os gaps de código identificados no gap analysis contra os **requisitos revisados** (correções da Unidade 2 do professor). Três features, uma por commit:

### 1. Histórico real do aluno (RF21)
- Endpoint `GET /api/historico/` retorna as tentativas do próprio aluno (total, acertos, itens).
- `StudentDashboard` calcula nível/pontos/aproveitamento e lista as tentativas a partir de dados reais (antes era mock).

### 2. Turmas (RF23/RF24)
- Model `Turma` (nome, série, professor) + vínculo `Usuario.turma`.
- Endpoints **somente professor** (`IsProfessor`, atende RNF14): listar/criar turmas e adicionar aluno por email.
- Relatório aceita `?turma=<id>` para filtrar por turma.
- Painel do professor: seletor de turma (Geral + turmas), modais de nova turma e adicionar aluno.

### 3. Atividades pedagógicas e Quiz (RF12/RF14/RF16)
- Models `Atividade` + `Pergunta`; admin com inline para cadastrar/remover (RF12/RF14 via Django Admin, RNF06).
- Endpoints `/api/atividades/` e `/api/atividades/<id>/`.
- `QuestionsScreen` carrega o quiz do backend (antes hardcoded); migration de seed com os quizzes de Nível 1 e 2.

## Não tocado (deploy)
- Nada de `settings.py`, portas, CORS, URLs, `vite.config.ts` ou `api.ts`.

## ⚠️ Atenção para o revisor
- **Migrations escritas à mão** (0007, 0008, 0009) — o ambiente local não tem Django/deps para rodar `makemigrations`. **Favor rodar `python manage.py makemigrations --check` (deve dizer "no changes") e `migrate` antes de aceitar.**
- O quiz é corrigido no cliente (o endpoint expõe `correta`), mantendo o comportamento anterior. Persistir a pontuação do quiz no histórico ficou de fora (RF21 cobre as tentativas de montagem).
- Continua pendente (fora desta PR): testes em `quickstart/tests.py` importam `validador.services`, módulo inexistente.

## Validação local
- `tsc --noEmit` ✅ · `npm run build` ✅ · lint dos arquivos alterados limpo ✅ · `py_compile` backend ✅