### PR TITLE
feat: interface de gerenciar conteudo (professor add/remove morfemas, palavras, atividades)

### DIFF
--- a/backend/core/serializers.py
+++ b/backend/core/serializers.py
@@ -1,5 +1,5 @@
 from rest_framework import serializers
-from core.models import Usuario, Morfema, Turma, Atividade, Pergunta
+from core.models import Usuario, Morfema, PalavraValida, Turma, Atividade, Pergunta
 
 
 class UsuarioSerializer(serializers.ModelSerializer):
@@ -13,6 +13,12 @@ class MorfemaSerializer(serializers.ModelSerializer):
         model = Morfema
         fields = ["id", "texto", "tipo", "cor"]
 
+
+
+class PalavraValidaSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = PalavraValida
+        fields = ["id", "texto", "processo_morfologico"]
 
 
 class TurmaSerializer(serializers.ModelSerializer):
@@ -44,6 +50,30 @@ class AtividadeDetailSerializer(serializers.ModelSerializer):
     class Meta:
         model = Atividade
         fields = ["id", "titulo", "tipo", "nivel", "perguntas"]
+
+
+class PerguntaWriteSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Pergunta
+        fields = ["enunciado", "alternativas", "correta", "explicacao", "topico"]
+
+
+class AtividadeCreateSerializer(serializers.ModelSerializer):
+    """Criação de atividade com perguntas aninhadas (RF12)."""
+
+    perguntas = PerguntaWriteSerializer(many=True, required=False)
+
+    class Meta:
+        model = Atividade
+        fields = ["id", "titulo", "tipo", "nivel", "ativa", "perguntas"]
+        read_only_fields = ["id"]
+
+    def create(self, validated_data):
+        perguntas = validated_data.pop("perguntas", [])
+        atividade = Atividade.objects.create(**validated_data)
+        for p in perguntas:
+            Pergunta.objects.create(atividade=atividade, **p)
+        return atividade
 
 
 class BlocoSerializer(serializers.Serializer):

--- a/backend/core/tests.py
+++ b/backend/core/tests.py
@@ -1,7 +1,7 @@
 from rest_framework import status
 from rest_framework.test import APITestCase
 
-from core.models import Usuario, PalavraValida, Tentativa
+from core.models import Usuario, Morfema, PalavraValida, Tentativa, Atividade, Pergunta
 
 
 def criar_usuario(email, tipo=Usuario.ALUNO, senha="senha123", nome=""):
@@ -112,6 +112,80 @@ class ValidadorTests(APITestCase):
         self.assertTrue(
             Tentativa.objects.filter(usuario=self.aluno, palavra="xyz", acertou=False).exists()
         )
+
+
+class ConteudoAdminTests(APITestCase):
+    """RF04/06/08/10/12/14 — professor gerencia o catálogo; aluno é bloqueado."""
+
+    def setUp(self):
+        self.professor = criar_usuario("prof.adm@x.com", tipo=Usuario.PROFESSOR)
+        self.aluno = criar_usuario("aluno.adm@x.com", tipo=Usuario.ALUNO)
+
+    def test_professor_cria_e_remove_morfema(self):
+        self.client.force_authenticate(self.professor)
+        resp = self.client.post(
+            "/api/morfemas/", {"texto": "sub", "tipo": "prefixo", "cor": "bg-red-500"}, format="json"
+        )
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+        mid = resp.data["id"]
+        self.assertTrue(Morfema.objects.filter(id=mid).exists())
+
+        resp = self.client.delete(f"/api/morfemas/{mid}/")
+        self.assertEqual(resp.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertFalse(Morfema.objects.filter(id=mid).exists())
+
+    def test_aluno_nao_cria_nem_remove_morfema(self):
+        self.client.force_authenticate(self.aluno)
+        resp = self.client.post(
+            "/api/morfemas/", {"texto": "x", "tipo": "prefixo", "cor": "bg-red-500"}, format="json"
+        )
+        self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)
+        # mas o aluno PODE listar (jogo)
+        self.assertEqual(self.client.get("/api/morfemas/").status_code, status.HTTP_200_OK)
+
+    def test_professor_gerencia_palavra_valida_e_aluno_bloqueado(self):
+        self.client.force_authenticate(self.aluno)
+        self.assertEqual(self.client.get("/api/palavras/").status_code, status.HTTP_403_FORBIDDEN)
+
+        self.client.force_authenticate(self.professor)
+        resp = self.client.post(
+            "/api/palavras/", {"texto": "descristalizar", "processo_morfologico": "des + cristal + iz + ar"}, format="json"
+        )
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+        pid = resp.data["id"]
+        self.assertEqual(self.client.delete(f"/api/palavras/{pid}/").status_code, status.HTTP_204_NO_CONTENT)
+
+    def test_professor_cria_atividade_com_perguntas_e_remove(self):
+        self.client.force_authenticate(self.professor)
+        payload = {
+            "titulo": "Quiz Teste",
+            "tipo": "quiz",
+            "nivel": 1,
+            "perguntas": [
+                {
+                    "enunciado": "Prefixo de infeliz?",
+                    "alternativas": ["in-", "feliz", "-iz", "fel-"],
+                    "correta": 0,
+                    "explicacao": "in- indica negação.",
+                    "topico": "Prefixos",
+                }
+            ],
+        }
+        resp = self.client.post("/api/atividades/", payload, format="json")
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+        aid = resp.data["id"]
+        self.assertEqual(Pergunta.objects.filter(atividade_id=aid).count(), 1)
+
+        resp = self.client.delete(f"/api/atividades/{aid}/")
+        self.assertEqual(resp.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertFalse(Atividade.objects.filter(id=aid).exists())
+
+    def test_aluno_nao_cria_atividade(self):
+        self.client.force_authenticate(self.aluno)
+        resp = self.client.post(
+            "/api/atividades/", {"titulo": "x", "tipo": "quiz", "nivel": 1}, format="json"
+        )
+        self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)
 
 
 class RelatorioPermissaoTests(APITestCase):

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -2,7 +2,10 @@ from django.urls import path
 from core.views import (
     MeView,
     RegistroView,
-    MorfemaListView,
+    MorfemaListCreateView,
+    MorfemaDestroyView,
+    PalavraValidaListCreateView,
+    PalavraValidaDestroyView,
     ValidarPalavraView,
     ForgotPasswordView,
     ResetPasswordConfirmView,
@@ -10,8 +13,8 @@ from core.views import (
     RelatorioProfessorView,
     TurmaListCreateView,
     AdicionarAlunoTurmaView,
-    AtividadeListView,
-    AtividadeDetailView,
+    AtividadeListCreateView,
+    AtividadeRetrieveDestroyView,
 )
 
 urlpatterns = [
@@ -19,13 +22,15 @@ urlpatterns = [
     path("auth/registro/", RegistroView.as_view(), name="registro"),
     path("auth/forgot-password/", ForgotPasswordView.as_view(), name="forgot-password"),
     path("auth/reset-password/", ResetPasswordConfirmView.as_view(), name="reset-password"),
-    path("morfemas/", MorfemaListView.as_view(), name="morfemas"),
+    path("morfemas/", MorfemaListCreateView.as_view(), name="morfemas"),
+    path("morfemas/<int:pk>/", MorfemaDestroyView.as_view(), name="morfema-remover"),
+    path("palavras/", PalavraValidaListCreateView.as_view(), name="palavras"),
+    path("palavras/<int:pk>/", PalavraValidaDestroyView.as_view(), name="palavra-remover"),
     path("validar-palavra/", ValidarPalavraView.as_view(), name="validar-palavra"),
-    path("atividades/", AtividadeListView.as_view(), name="atividades"),
-    path("atividades/<int:pk>/", AtividadeDetailView.as_view(), name="atividade-detalhe"),
+    path("atividades/", AtividadeListCreateView.as_view(), name="atividades"),
+    path("atividades/<int:pk>/", AtividadeRetrieveDestroyView.as_view(), name="atividade-detalhe"),
     path("historico/", HistoricoAlunoView.as_view(), name="historico-aluno"),
     path("professor/relatorio/", RelatorioProfessorView.as_view(), name="relatorio-professor"),
     path("professor/turmas/", TurmaListCreateView.as_view(), name="turmas"),
     path("professor/turmas/<int:turma_id>/alunos/", AdicionarAlunoTurmaView.as_view(), name="turma-add-aluno"),
 ]
-

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -1,7 +1,14 @@
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated, AllowAny, BasePermission
-from rest_framework.generics import ListAPIView, CreateAPIView, ListCreateAPIView, RetrieveAPIView
+from rest_framework.generics import (
+    ListAPIView,
+    CreateAPIView,
+    ListCreateAPIView,
+    RetrieveAPIView,
+    DestroyAPIView,
+    RetrieveDestroyAPIView,
+)
 from rest_framework import status
 
 from urllib.parse import urlsplit
@@ -18,11 +25,13 @@ from core.models import Morfema, PalavraValida, Tentativa, Usuario, Turma, Ativi
 from core.serializers import (
     UsuarioSerializer,
     MorfemaSerializer,
+    PalavraValidaSerializer,
     ValidarPalavraSerializer,
     RegistroSerializer,
     TurmaSerializer,
     AtividadeSerializer,
     AtividadeDetailSerializer,
+    AtividadeCreateSerializer,
 )
 
 
@@ -50,15 +59,45 @@ class RegistroView(CreateAPIView):
     permission_classes = [AllowAny]
 
 
-class MorfemaListView(ListAPIView):
+class MorfemaListCreateView(ListCreateAPIView):
     queryset = Morfema.objects.all().order_by("tipo", "texto")
     serializer_class = MorfemaSerializer
-    permission_classes = [IsAuthenticated]
     # A paleta de blocos precisa SEMPRE do catálogo completo de morfemas.
     # Sem isto, a paginação global do DRF (PAGE_SIZE=10) corta a lista; como os
     # sufixos ficam por último na ordenação (prefixo < radical < sufixo), eles
     # desaparecem assim que o catálogo passa de 10 itens.
     pagination_class = None
+
+    def get_permissions(self):
+        # Alunos listam (jogo); apenas professores cadastram (RF04).
+        if self.request.method == "POST":
+            return [IsProfessor()]
+        return [IsAuthenticated()]
+
+
+class MorfemaDestroyView(DestroyAPIView):
+    """Remove um morfema do catálogo (RF06)."""
+
+    queryset = Morfema.objects.all()
+    serializer_class = MorfemaSerializer
+    permission_classes = [IsProfessor]
+
+
+class PalavraValidaListCreateView(ListCreateAPIView):
+    """Lista e cadastra palavras válidas (RF08). Restrito a professores."""
+
+    queryset = PalavraValida.objects.all().order_by("texto")
+    serializer_class = PalavraValidaSerializer
+    permission_classes = [IsProfessor]
+    pagination_class = None
+
+
+class PalavraValidaDestroyView(DestroyAPIView):
+    """Remove uma palavra válida do catálogo (RF10)."""
+
+    queryset = PalavraValida.objects.all()
+    serializer_class = PalavraValidaSerializer
+    permission_classes = [IsProfessor]
 
 
 class ValidarPalavraView(APIView):
@@ -92,11 +131,13 @@ class ValidarPalavraView(APIView):
         })
 
 
-class AtividadeListView(ListAPIView):
-    """Lista atividades ativas (RF16). Filtra por ?tipo=quiz|montagem."""
+class AtividadeListCreateView(ListCreateAPIView):
+    """Lista atividades ativas (RF16) e cadastra novas (RF12).
 
-    serializer_class = AtividadeSerializer
-    permission_classes = [IsAuthenticated]
+    GET: qualquer usuário autenticado (o aluno lista para jogar).
+    POST: apenas professor, com as perguntas aninhadas.
+    """
+
     pagination_class = None
 
     def get_queryset(self):
@@ -106,13 +147,28 @@ class AtividadeListView(ListAPIView):
             qs = qs.filter(tipo=tipo)
         return qs
 
+    def get_serializer_class(self):
+        return AtividadeCreateSerializer if self.request.method == "POST" else AtividadeSerializer
 
-class AtividadeDetailView(RetrieveAPIView):
-    """Detalha uma atividade com suas perguntas (RF16)."""
+    def get_permissions(self):
+        if self.request.method == "POST":
+            return [IsProfessor()]
+        return [IsAuthenticated()]
 
-    queryset = Atividade.objects.filter(ativa=True)
+
+class AtividadeRetrieveDestroyView(RetrieveDestroyAPIView):
+    """Detalha uma atividade com perguntas (RF16) e permite removê-la (RF14).
+
+    GET: qualquer autenticado. DELETE: apenas professor.
+    """
+
+    queryset = Atividade.objects.all()
     serializer_class = AtividadeDetailSerializer
-    permission_classes = [IsAuthenticated]
+
+    def get_permissions(self):
+        if self.request.method == "DELETE":
+            return [IsProfessor()]
+        return [IsAuthenticated()]
 
 
 class HistoricoAlunoView(APIView):

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -10,6 +10,7 @@ import { QuestionsScreen } from './components/QuestionsScreen';
 import { BlockJoining } from './components/BlockJoining';
 import { LearningScreen } from './components/LearningScreen';
 import { ProfessorDashboard } from './components/ProfessorDashboard';
+import { ManageContent } from './components/ManageContent';
 
 // Guarda de rota: só renderiza o conteúdo se houver sessão (token).
 // Quando a sessão expira, o AppState (que ouve AUTH_EXPIRED_EVENT) zera o
@@ -86,6 +87,14 @@ export default function App() {
             element={
               <PrivateRoute>
                 <ProfessorDashboard />
+              </PrivateRoute>
+            }
+          />
+          <Route
+            path="/professor/conteudo"
+            element={
+              <PrivateRoute>
+                <ManageContent />
               </PrivateRoute>
             }
           />

--- a/frontend/src/app/components/ManageContent.tsx
+++ b/frontend/src/app/components/ManageContent.tsx
@@ -1,0 +1,328 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router';
+import { ArrowLeft, Plus, Trash2, Loader2 } from 'lucide-react';
+import { api } from '../../lib/api';
+
+type Tab = 'morfemas' | 'palavras' | 'atividades';
+
+type Morfema = { id: number; texto: string; tipo: 'prefixo' | 'radical' | 'sufixo'; cor: string };
+type Palavra = { id: number; texto: string; processo_morfologico: string };
+type Atividade = { id: number; titulo: string; tipo: string; nivel: number };
+type PerguntaForm = { enunciado: string; alternativas: string[]; correta: number; explicacao: string; topico: string };
+
+const COR_POR_TIPO: Record<Morfema['tipo'], string> = {
+  prefixo: 'bg-red-500',
+  radical: 'bg-blue-600',
+  sufixo: 'bg-yellow-500',
+};
+
+const perguntaVazia = (): PerguntaForm => ({
+  enunciado: '',
+  alternativas: ['', '', '', ''],
+  correta: 0,
+  explicacao: '',
+  topico: '',
+});
+
+export function ManageContent() {
+  const [tab, setTab] = useState<Tab>('morfemas');
+  const [reloadTick, setReloadTick] = useState(0);
+  const [erro, setErro] = useState<string | null>(null);
+  const [salvando, setSalvando] = useState(false);
+
+  const [morfemas, setMorfemas] = useState<Morfema[]>([]);
+  const [palavras, setPalavras] = useState<Palavra[]>([]);
+  const [atividades, setAtividades] = useState<Atividade[]>([]);
+  const [carregando, setCarregando] = useState(true);
+
+  // Formulário Morfema
+  const [mTexto, setMTexto] = useState('');
+  const [mTipo, setMTipo] = useState<Morfema['tipo']>('prefixo');
+  // Formulário Palavra
+  const [pTexto, setPTexto] = useState('');
+  const [pProcesso, setPProcesso] = useState('');
+  // Formulário Atividade
+  const [aTitulo, setATitulo] = useState('');
+  const [aTipo, setATipo] = useState<'quiz' | 'montagem'>('quiz');
+  const [aNivel, setANivel] = useState(1);
+  const [aPerguntas, setAPerguntas] = useState<PerguntaForm[]>([perguntaVazia()]);
+
+  useEffect(() => {
+    let active = true;
+    const url = tab === 'morfemas' ? '/morfemas/' : tab === 'palavras' ? '/palavras/' : '/atividades/';
+    api
+      .get(url)
+      .then(({ data }) => {
+        if (!active) return;
+        const lista = Array.isArray(data) ? data : (data?.results ?? []);
+        if (tab === 'morfemas') setMorfemas(lista);
+        else if (tab === 'palavras') setPalavras(lista);
+        else setAtividades(lista);
+      })
+      .catch((err) => {
+        console.error('Falha ao carregar:', err);
+        if (active) setErro('Não foi possível carregar a lista.');
+      })
+      .finally(() => {
+        if (active) setCarregando(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [tab, reloadTick]);
+
+  const trocarTab = (t: Tab) => {
+    setTab(t);
+    setErro(null);
+    setCarregando(true);
+  };
+
+  const recarregar = () => setReloadTick((t) => t + 1);
+
+  const remover = async (url: string) => {
+    if (!window.confirm('Tem certeza que deseja excluir? Esta ação não pode ser desfeita.')) return;
+    try {
+      await api.delete(url);
+      recarregar();
+    } catch (err) {
+      console.error('Falha ao excluir:', err);
+      setErro('Não foi possível excluir. Tente novamente.');
+    }
+  };
+
+  const addMorfema = async () => {
+    if (!mTexto.trim()) return;
+    setSalvando(true);
+    setErro(null);
+    try {
+      await api.post('/morfemas/', { texto: mTexto.trim(), tipo: mTipo, cor: COR_POR_TIPO[mTipo] });
+      setMTexto('');
+      recarregar();
+    } catch {
+      setErro('Não foi possível adicionar o morfema.');
+    } finally {
+      setSalvando(false);
+    }
+  };
+
+  const addPalavra = async () => {
+    if (!pTexto.trim() || !pProcesso.trim()) return;
+    setSalvando(true);
+    setErro(null);
+    try {
+      await api.post('/palavras/', { texto: pTexto.trim().toLowerCase(), processo_morfologico: pProcesso.trim() });
+      setPTexto('');
+      setPProcesso('');
+      recarregar();
+    } catch {
+      setErro('Não foi possível adicionar a palavra (talvez já exista).');
+    } finally {
+      setSalvando(false);
+    }
+  };
+
+  const addAtividade = async () => {
+    if (!aTitulo.trim()) return;
+    const perguntas = aTipo === 'quiz'
+      ? aPerguntas
+          .filter((p) => p.enunciado.trim() && p.alternativas.every((a) => a.trim()))
+          .map((p) => ({ ...p, enunciado: p.enunciado.trim() }))
+      : [];
+    if (aTipo === 'quiz' && perguntas.length === 0) {
+      setErro('Adicione pelo menos uma pergunta completa (enunciado + 4 alternativas).');
+      return;
+    }
+    setSalvando(true);
+    setErro(null);
+    try {
+      await api.post('/atividades/', { titulo: aTitulo.trim(), tipo: aTipo, nivel: aNivel, perguntas });
+      setATitulo('');
+      setANivel(1);
+      setAPerguntas([perguntaVazia()]);
+      recarregar();
+    } catch {
+      setErro('Não foi possível adicionar a atividade.');
+    } finally {
+      setSalvando(false);
+    }
+  };
+
+  // Helpers do builder de perguntas
+  const setPergunta = (i: number, patch: Partial<PerguntaForm>) =>
+    setAPerguntas((ps) => ps.map((p, idx) => (idx === i ? { ...p, ...patch } : p)));
+  const setAlternativa = (i: number, j: number, valor: string) =>
+    setAPerguntas((ps) => ps.map((p, idx) => (idx === i ? { ...p, alternativas: p.alternativas.map((a, k) => (k === j ? valor : a)) } : p)));
+
+  const inputCls = 'w-full px-3 py-2 bg-input-background rounded-lg border border-border focus:outline-none focus:ring-2 focus:ring-primary text-sm';
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-yellow-50 to-red-50 p-3 sm:p-4">
+      <div className="max-w-4xl mx-auto">
+        <div className="flex items-center justify-between mb-4 sm:mb-6 gap-2">
+          <Link to="/professor/dashboard" className="flex items-center gap-1 sm:gap-2 text-muted-foreground hover:text-foreground shrink-0">
+            <ArrowLeft className="w-5 h-5" /> <span className="hidden sm:inline">Voltar</span>
+          </Link>
+          <h1 className="text-lg sm:text-2xl text-center">Gerenciar Conteúdo</h1>
+          <div className="w-8 sm:w-20" />
+        </div>
+
+        {/* Abas */}
+        <div className="flex gap-2 mb-4 overflow-x-auto">
+          {([['morfemas', 'Morfemas'], ['palavras', 'Palavras'], ['atividades', 'Atividades']] as [Tab, string][]).map(([t, label]) => (
+            <button
+              key={t}
+              onClick={() => trocarTab(t)}
+              className={`px-4 py-2 rounded-xl whitespace-nowrap text-sm transition-all ${
+                tab === t ? 'bg-gradient-to-r from-blue-600 to-blue-700 text-white shadow-md' : 'bg-white hover:bg-gray-100'
+              }`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+
+        {erro && (
+          <div className="p-3 mb-4 bg-red-50 border-l-4 border-red-500 rounded-lg text-sm text-red-700">{erro}</div>
+        )}
+
+        {/* ---------- MORFEMAS ---------- */}
+        {tab === 'morfemas' && (
+          <div className="space-y-4">
+            <div className="bg-white rounded-2xl shadow-lg p-4 sm:p-6">
+              <h2 className="text-base sm:text-lg mb-3">Adicionar Morfema</h2>
+              <div className="flex flex-col sm:flex-row gap-3">
+                <input value={mTexto} onChange={(e) => setMTexto(e.target.value)} placeholder="Texto (ex: in)" className={inputCls} />
+                <select value={mTipo} onChange={(e) => setMTipo(e.target.value as Morfema['tipo'])} className={`${inputCls} sm:w-48`}>
+                  <option value="prefixo">Prefixo</option>
+                  <option value="radical">Radical</option>
+                  <option value="sufixo">Sufixo</option>
+                </select>
+                <button onClick={addMorfema} disabled={salvando || !mTexto.trim()} className="px-4 py-2 bg-primary text-white rounded-lg hover:bg-primary/90 disabled:opacity-50 flex items-center justify-center gap-2 shrink-0">
+                  {salvando ? <Loader2 className="w-4 h-4 animate-spin" /> : <Plus className="w-4 h-4" />} Adicionar
+                </button>
+              </div>
+            </div>
+            <ListaCard carregando={carregando} vazio={morfemas.length === 0} vazioMsg="Nenhum morfema cadastrado.">
+              {morfemas.map((m) => (
+                <li key={m.id} className="flex items-center gap-3 p-3 border-b border-border last:border-0">
+                  <span className={`${m.cor} text-white px-3 py-1 rounded-md text-sm`}>{m.texto}</span>
+                  <span className="text-sm text-muted-foreground flex-1 capitalize">{m.tipo}</span>
+                  <button onClick={() => remover(`/morfemas/${m.id}/`)} className="text-red-500 hover:text-red-700 p-1"><Trash2 className="w-4 h-4" /></button>
+                </li>
+              ))}
+            </ListaCard>
+          </div>
+        )}
+
+        {/* ---------- PALAVRAS ---------- */}
+        {tab === 'palavras' && (
+          <div className="space-y-4">
+            <div className="bg-white rounded-2xl shadow-lg p-4 sm:p-6">
+              <h2 className="text-base sm:text-lg mb-3">Adicionar Palavra Válida</h2>
+              <div className="space-y-3">
+                <input value={pTexto} onChange={(e) => setPTexto(e.target.value)} placeholder="Palavra (ex: infelizmente)" className={inputCls} />
+                <input value={pProcesso} onChange={(e) => setPProcesso(e.target.value)} placeholder="Processo morfológico (ex: in + feliz + mente)" className={inputCls} />
+                <button onClick={addPalavra} disabled={salvando || !pTexto.trim() || !pProcesso.trim()} className="px-4 py-2 bg-primary text-white rounded-lg hover:bg-primary/90 disabled:opacity-50 flex items-center gap-2">
+                  {salvando ? <Loader2 className="w-4 h-4 animate-spin" /> : <Plus className="w-4 h-4" />} Adicionar
+                </button>
+              </div>
+            </div>
+            <ListaCard carregando={carregando} vazio={palavras.length === 0} vazioMsg="Nenhuma palavra cadastrada.">
+              {palavras.map((p) => (
+                <li key={p.id} className="flex items-center gap-3 p-3 border-b border-border last:border-0">
+                  <div className="flex-1 min-w-0">
+                    <div className="text-sm">{p.texto}</div>
+                    <div className="text-xs text-muted-foreground truncate">{p.processo_morfologico}</div>
+                  </div>
+                  <button onClick={() => remover(`/palavras/${p.id}/`)} className="text-red-500 hover:text-red-700 p-1"><Trash2 className="w-4 h-4" /></button>
+                </li>
+              ))}
+            </ListaCard>
+          </div>
+        )}
+
+        {/* ---------- ATIVIDADES ---------- */}
+        {tab === 'atividades' && (
+          <div className="space-y-4">
+            <div className="bg-white rounded-2xl shadow-lg p-4 sm:p-6">
+              <h2 className="text-base sm:text-lg mb-3">Adicionar Atividade</h2>
+              <div className="flex flex-col sm:flex-row gap-3 mb-3">
+                <input value={aTitulo} onChange={(e) => setATitulo(e.target.value)} placeholder="Título" className={inputCls} />
+                <select value={aTipo} onChange={(e) => setATipo(e.target.value as 'quiz' | 'montagem')} className={`${inputCls} sm:w-40`}>
+                  <option value="quiz">Quiz</option>
+                  <option value="montagem">Montagem</option>
+                </select>
+                <select value={aNivel} onChange={(e) => setANivel(Number(e.target.value))} className={`${inputCls} sm:w-32`}>
+                  <option value={1}>Nível 1</option>
+                  <option value={2}>Nível 2</option>
+                  <option value={3}>Nível 3</option>
+                </select>
+              </div>
+
+              {aTipo === 'quiz' && (
+                <div className="space-y-3">
+                  {aPerguntas.map((p, i) => (
+                    <div key={i} className="border border-border rounded-xl p-3 space-y-2">
+                      <div className="flex items-center justify-between">
+                        <span className="text-sm text-muted-foreground">Pergunta {i + 1}</span>
+                        {aPerguntas.length > 1 && (
+                          <button onClick={() => setAPerguntas((ps) => ps.filter((_, idx) => idx !== i))} className="text-red-500 hover:text-red-700"><Trash2 className="w-4 h-4" /></button>
+                        )}
+                      </div>
+                      <input value={p.enunciado} onChange={(e) => setPergunta(i, { enunciado: e.target.value })} placeholder="Enunciado" className={inputCls} />
+                      <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                        {p.alternativas.map((alt, j) => (
+                          <label key={j} className="flex items-center gap-2">
+                            <input type="radio" name={`correta-${i}`} checked={p.correta === j} onChange={() => setPergunta(i, { correta: j })} className="shrink-0" />
+                            <input value={alt} onChange={(e) => setAlternativa(i, j, e.target.value)} placeholder={`Alternativa ${j + 1}`} className={inputCls} />
+                          </label>
+                        ))}
+                      </div>
+                      <p className="text-xs text-muted-foreground">Marque o círculo da alternativa correta.</p>
+                      <input value={p.topico} onChange={(e) => setPergunta(i, { topico: e.target.value })} placeholder="Tópico (ex: Prefixos)" className={inputCls} />
+                      <input value={p.explicacao} onChange={(e) => setPergunta(i, { explicacao: e.target.value })} placeholder="Explicação (opcional)" className={inputCls} />
+                    </div>
+                  ))}
+                  <button onClick={() => setAPerguntas((ps) => [...ps, perguntaVazia()])} className="text-sm text-primary hover:underline flex items-center gap-1">
+                    <Plus className="w-4 h-4" /> Adicionar pergunta
+                  </button>
+                </div>
+              )}
+
+              <button onClick={addAtividade} disabled={salvando || !aTitulo.trim()} className="mt-4 px-4 py-2 bg-primary text-white rounded-lg hover:bg-primary/90 disabled:opacity-50 flex items-center gap-2">
+                {salvando ? <Loader2 className="w-4 h-4 animate-spin" /> : <Plus className="w-4 h-4" />} Criar Atividade
+              </button>
+            </div>
+            <ListaCard carregando={carregando} vazio={atividades.length === 0} vazioMsg="Nenhuma atividade cadastrada.">
+              {atividades.map((a) => (
+                <li key={a.id} className="flex items-center gap-3 p-3 border-b border-border last:border-0">
+                  <div className="flex-1 min-w-0">
+                    <div className="text-sm truncate">{a.titulo}</div>
+                    <div className="text-xs text-muted-foreground capitalize">{a.tipo} · Nível {a.nivel}</div>
+                  </div>
+                  <button onClick={() => remover(`/atividades/${a.id}/`)} className="text-red-500 hover:text-red-700 p-1"><Trash2 className="w-4 h-4" /></button>
+                </li>
+              ))}
+            </ListaCard>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ListaCard({ carregando, vazio, vazioMsg, children }: { carregando: boolean; vazio: boolean; vazioMsg: string; children: React.ReactNode }) {
+  return (
+    <div className="bg-white rounded-2xl shadow-lg overflow-hidden">
+      {carregando ? (
+        <div className="flex items-center justify-center gap-2 py-10 text-muted-foreground">
+          <Loader2 className="w-5 h-5 animate-spin" /> Carregando...
+        </div>
+      ) : vazio ? (
+        <div className="text-center text-muted-foreground py-10 text-sm">{vazioMsg}</div>
+      ) : (
+        <ul>{children}</ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/app/components/ProfessorDashboard.tsx
+++ b/frontend/src/app/components/ProfessorDashboard.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router';
-import { Users, TrendingUp, Award, AlertCircle, LogOut, User, Loader2, Plus, GraduationCap, X } from 'lucide-react';
+import { Users, TrendingUp, Award, AlertCircle, LogOut, User, Loader2, Plus, GraduationCap, X, Settings } from 'lucide-react';
 import {
   BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Cell,
 } from 'recharts';
@@ -149,7 +149,13 @@ export function ProfessorDashboard() {
             </div>
           </div>
           <div className="flex items-center gap-2 sm:gap-4 shrink-0">
-            <div className="text-right hidden sm:block">
+            <Link
+              to="/professor/conteudo"
+              className="flex items-center gap-1.5 px-2 sm:px-3 py-1.5 sm:py-2 bg-gray-100 hover:bg-gray-200 rounded-xl text-xs sm:text-sm transition-colors"
+            >
+              <Settings className="w-4 h-4" /> <span className="hidden sm:inline">Gerenciar Conteúdo</span>
+            </Link>
+            <div className="text-right hidden md:block">
               <div className="text-sm text-muted-foreground">Prof.</div>
               <div>{usuario?.first_name?.trim() || usuario?.username}</div>
             </div>


### PR DESCRIPTION
## Resumo
A equipe decidiu levar o "adicionar/excluir" do catálogo (antes só via Django Admin) para uma **interface no frontend**, acessível pelo **professor**. Esta PR implementa isso ponta a ponta.

### Backend (API restrita a professor via `IsProfessor`)
- Morfemas: `POST /api/morfemas/` + `DELETE /api/morfemas/<id>/` (o `GET` continua aberto ao aluno para o jogo). RF04/RF06.
- Palavras válidas: `GET/POST /api/palavras/` + `DELETE /api/palavras/<id>/`. RF08/RF10.
- Atividades: `POST /api/atividades/` (com perguntas aninhadas) + `DELETE /api/atividades/<id>/`. RF12/RF14.
- Testes de permissão: professor cria/remove; aluno recebe 403 (mas ainda lista morfemas).

### Frontend
- Nova tela `/professor/conteudo` com 3 abas (Morfemas, Palavras, Atividades): lista + adicionar + excluir.
- Quiz: construtor de perguntas (enunciado, 4 alternativas, marca a correta, tópico, explicação).
- Botão "Gerenciar Conteúdo" no painel do professor.

## Decisões
- **Acesso = professor** (reusa o login existente; sem criar perfil admin novo). O backend bloqueia não-professores.
- Escopo **add + remover** (editar/listar fora, conforme MoSCoW revisado). Listar é usado só para permitir a exclusão.
- **Não** contradiz o RNF06 na prática: o Django Admin continua existindo; isto é uma conveniência adicional pedida pela equipe.

## Validação
- Backend: `python manage.py test core` → **12 testes OK** (inclui os novos de permissão do admin).
- Frontend: `tsc` ✅ · `lint` ✅ · `build` ✅.
- Nada de deploy tocado (portas/CORS/URLs/settings).

Obs.: como só adiciona endpoints/tela (sem migration nova), não precisa migrar nada no deploy.